### PR TITLE
feat: rcc enums

### DIFF
--- a/src/sf32lb52x/hpsys_rcc/regs.rs
+++ b/src/sf32lb52x/hpsys_rcc/regs.rs
@@ -18,26 +18,26 @@ impl Cfgr {
     #[doc = "pclk_hpsys = hclk_hpsys / (2^PDIV1), by default divided by 2"]
     #[must_use]
     #[inline(always)]
-    pub const fn pdiv1(&self) -> u8 {
+    pub const fn pdiv1(&self) -> super::vals::Pdiv {
         let val = (self.0 >> 8usize) & 0x07;
-        val as u8
+        super::vals::Pdiv::from_bits(val as u8)
     }
     #[doc = "pclk_hpsys = hclk_hpsys / (2^PDIV1), by default divided by 2"]
     #[inline(always)]
-    pub const fn set_pdiv1(&mut self, val: u8) {
-        self.0 = (self.0 & !(0x07 << 8usize)) | (((val as u32) & 0x07) << 8usize);
+    pub const fn set_pdiv1(&mut self, val: super::vals::Pdiv) {
+        self.0 = (self.0 & !(0x07 << 8usize)) | (((val.to_bits() as u32) & 0x07) << 8usize);
     }
     #[doc = "pclk2_hpsys = hclk_hpsys / (2^PDIV2), by default divided by 16"]
     #[must_use]
     #[inline(always)]
-    pub const fn pdiv2(&self) -> u8 {
+    pub const fn pdiv2(&self) -> super::vals::Pdiv {
         let val = (self.0 >> 12usize) & 0x07;
-        val as u8
+        super::vals::Pdiv::from_bits(val as u8)
     }
     #[doc = "pclk2_hpsys = hclk_hpsys / (2^PDIV2), by default divided by 16"]
     #[inline(always)]
-    pub const fn set_pdiv2(&mut self, val: u8) {
-        self.0 = (self.0 & !(0x07 << 12usize)) | (((val as u32) & 0x07) << 12usize);
+    pub const fn set_pdiv2(&mut self, val: super::vals::Pdiv) {
+        self.0 = (self.0 & !(0x07 << 12usize)) | (((val.to_bits() as u32) & 0x07) << 12usize);
     }
     #[doc = "systick reference clock is systick reference clock source (selected by SEL_TICK) devided by TICKDIV"]
     #[must_use]
@@ -73,7 +73,7 @@ impl defmt::Format for Cfgr {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "Cfgr {{ hdiv: {=u8:?}, pdiv1: {=u8:?}, pdiv2: {=u8:?}, tickdiv: {=u8:?} }}",
+            "Cfgr {{ hdiv: {=u8:?}, pdiv1: {:?}, pdiv2: {:?}, tickdiv: {=u8:?} }}",
             self.hdiv(),
             self.pdiv1(),
             self.pdiv2(),
@@ -89,85 +89,85 @@ impl Csr {
     #[doc = "select clk_hpsys source 0 - clk_hrc48; 1 - clk_hxt48; 2 - reserved; 3 - clk_dll1"]
     #[must_use]
     #[inline(always)]
-    pub const fn sel_sys(&self) -> super::vals::SelSys {
+    pub const fn sel_sys(&self) -> super::vals::Sysclk {
         let val = (self.0 >> 0usize) & 0x03;
-        super::vals::SelSys::from_bits(val as u8)
+        super::vals::Sysclk::from_bits(val as u8)
     }
     #[doc = "select clk_hpsys source 0 - clk_hrc48; 1 - clk_hxt48; 2 - reserved; 3 - clk_dll1"]
     #[inline(always)]
-    pub const fn set_sel_sys(&mut self, val: super::vals::SelSys) {
+    pub const fn set_sel_sys(&mut self, val: super::vals::Sysclk) {
         self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
     }
     #[doc = "select clk_hpsys source 0 - selected by SEL_SYS; 1 - clk_wdt"]
     #[must_use]
     #[inline(always)]
-    pub const fn sel_sys_lp(&self) -> bool {
+    pub const fn sel_sys_lp(&self) -> super::vals::mux::Lpsel {
         let val = (self.0 >> 2usize) & 0x01;
-        val != 0
+        super::vals::mux::Lpsel::from_bits(val as u8)
     }
     #[doc = "select clk_hpsys source 0 - selected by SEL_SYS; 1 - clk_wdt"]
     #[inline(always)]
-    pub const fn set_sel_sys_lp(&mut self, val: bool) {
-        self.0 = (self.0 & !(0x01 << 2usize)) | (((val as u32) & 0x01) << 2usize);
+    pub const fn set_sel_sys_lp(&mut self, val: super::vals::mux::Lpsel) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val.to_bits() as u32) & 0x01) << 2usize);
     }
     #[doc = "selet MPI1 function clock 0 - clk_peri_hpsys; 1 - clk_dll1; 2 - clk_dll2; 3 - reserved"]
     #[must_use]
     #[inline(always)]
-    pub const fn sel_mpi1(&self) -> u8 {
+    pub const fn sel_mpi1(&self) -> super::vals::mux::Mpisel {
         let val = (self.0 >> 4usize) & 0x03;
-        val as u8
+        super::vals::mux::Mpisel::from_bits(val as u8)
     }
     #[doc = "selet MPI1 function clock 0 - clk_peri_hpsys; 1 - clk_dll1; 2 - clk_dll2; 3 - reserved"]
     #[inline(always)]
-    pub const fn set_sel_mpi1(&mut self, val: u8) {
-        self.0 = (self.0 & !(0x03 << 4usize)) | (((val as u32) & 0x03) << 4usize);
+    pub const fn set_sel_mpi1(&mut self, val: super::vals::mux::Mpisel) {
+        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
     }
     #[doc = "selet MPI2 function clock 0 - clk_peri_hpsys; 1 - clk_dll1; 2 - clk_dll2; 3 - reserved"]
     #[must_use]
     #[inline(always)]
-    pub const fn sel_mpi2(&self) -> u8 {
+    pub const fn sel_mpi2(&self) -> super::vals::mux::Mpisel {
         let val = (self.0 >> 6usize) & 0x03;
-        val as u8
+        super::vals::mux::Mpisel::from_bits(val as u8)
     }
     #[doc = "selet MPI2 function clock 0 - clk_peri_hpsys; 1 - clk_dll1; 2 - clk_dll2; 3 - reserved"]
     #[inline(always)]
-    pub const fn set_sel_mpi2(&mut self, val: u8) {
-        self.0 = (self.0 & !(0x03 << 6usize)) | (((val as u32) & 0x03) << 6usize);
+    pub const fn set_sel_mpi2(&mut self, val: super::vals::mux::Mpisel) {
+        self.0 = (self.0 & !(0x03 << 6usize)) | (((val.to_bits() as u32) & 0x03) << 6usize);
     }
     #[doc = "select clk_peri_hpsys source used by USART/SPI/I2C/GPTIM2/BTIM2 0 - clk_hrc48; 1 - clk_hxt48"]
     #[must_use]
     #[inline(always)]
-    pub const fn sel_peri(&self) -> super::vals::SelPeri {
+    pub const fn sel_peri(&self) -> super::vals::mux::Perisel {
         let val = (self.0 >> 12usize) & 0x01;
-        super::vals::SelPeri::from_bits(val as u8)
+        super::vals::mux::Perisel::from_bits(val as u8)
     }
     #[doc = "select clk_peri_hpsys source used by USART/SPI/I2C/GPTIM2/BTIM2 0 - clk_hrc48; 1 - clk_hxt48"]
     #[inline(always)]
-    pub const fn set_sel_peri(&mut self, val: super::vals::SelPeri) {
+    pub const fn set_sel_peri(&mut self, val: super::vals::mux::Perisel) {
         self.0 = (self.0 & !(0x01 << 12usize)) | (((val.to_bits() as u32) & 0x01) << 12usize);
     }
     #[doc = "select clock source for systick reference 0 - clk_rtc; 1 - reserved; 2 - clk_hrc48; 3 - clk_hxt48"]
     #[must_use]
     #[inline(always)]
-    pub const fn sel_tick(&self) -> super::vals::SelTick {
+    pub const fn sel_tick(&self) -> super::vals::mux::Ticksel {
         let val = (self.0 >> 13usize) & 0x03;
-        super::vals::SelTick::from_bits(val as u8)
+        super::vals::mux::Ticksel::from_bits(val as u8)
     }
     #[doc = "select clock source for systick reference 0 - clk_rtc; 1 - reserved; 2 - clk_hrc48; 3 - clk_hxt48"]
     #[inline(always)]
-    pub const fn set_sel_tick(&mut self, val: super::vals::SelTick) {
+    pub const fn set_sel_tick(&mut self, val: super::vals::mux::Ticksel) {
         self.0 = (self.0 & !(0x03 << 13usize)) | (((val.to_bits() as u32) & 0x03) << 13usize);
     }
     #[doc = "select USB source clock 0 - clk_hpsys; 1 - clk_dll2"]
     #[must_use]
     #[inline(always)]
-    pub const fn sel_usbc(&self) -> super::vals::SelUsbc {
+    pub const fn sel_usbc(&self) -> super::vals::mux::Usbsel {
         let val = (self.0 >> 15usize) & 0x01;
-        super::vals::SelUsbc::from_bits(val as u8)
+        super::vals::mux::Usbsel::from_bits(val as u8)
     }
     #[doc = "select USB source clock 0 - clk_hpsys; 1 - clk_dll2"]
     #[inline(always)]
-    pub const fn set_sel_usbc(&mut self, val: super::vals::SelUsbc) {
+    pub const fn set_sel_usbc(&mut self, val: super::vals::mux::Usbsel) {
         self.0 = (self.0 & !(0x01 << 15usize)) | (((val.to_bits() as u32) & 0x01) << 15usize);
     }
 }
@@ -193,7 +193,7 @@ impl core::fmt::Debug for Csr {
 #[cfg(feature = "defmt")]
 impl defmt::Format for Csr {
     fn format(&self, f: defmt::Formatter) {
-        defmt :: write ! (f , "Csr {{ sel_sys: {:?}, sel_sys_lp: {=bool:?}, sel_mpi1: {=u8:?}, sel_mpi2: {=u8:?}, sel_peri: {:?}, sel_tick: {:?}, sel_usbc: {:?} }}" , self . sel_sys () , self . sel_sys_lp () , self . sel_mpi1 () , self . sel_mpi2 () , self . sel_peri () , self . sel_tick () , self . sel_usbc ())
+        defmt :: write ! (f , "Csr {{ sel_sys: {:?}, sel_sys_lp: {:?}, sel_mpi1: {:?}, sel_mpi2: {:?}, sel_peri: {:?}, sel_tick: {:?}, sel_usbc: {:?} }}" , self . sel_sys () , self . sel_sys_lp () , self . sel_mpi1 () , self . sel_mpi2 () , self . sel_peri () , self . sel_tick () , self . sel_usbc ())
     }
 }
 #[doc = "Debug Clock Register"]
@@ -547,14 +547,14 @@ impl Dllcr {
     #[doc = "DLL lock freqency is decided by STG. DLL output frequency is (STG+1)*24MHz e.g. STG=9,DLL output is 240M"]
     #[must_use]
     #[inline(always)]
-    pub const fn stg(&self) -> u8 {
+    pub const fn stg(&self) -> super::vals::Dllstg {
         let val = (self.0 >> 2usize) & 0x0f;
-        val as u8
+        super::vals::Dllstg::from_bits(val as u8)
     }
     #[doc = "DLL lock freqency is decided by STG. DLL output frequency is (STG+1)*24MHz e.g. STG=9,DLL output is 240M"]
     #[inline(always)]
-    pub const fn set_stg(&mut self, val: u8) {
-        self.0 = (self.0 & !(0x0f << 2usize)) | (((val as u32) & 0x0f) << 2usize);
+    pub const fn set_stg(&mut self, val: super::vals::Dllstg) {
+        self.0 = (self.0 & !(0x0f << 2usize)) | (((val.to_bits() as u32) & 0x0f) << 2usize);
     }
     #[must_use]
     #[inline(always)]
@@ -755,7 +755,7 @@ impl core::fmt::Debug for Dllcr {
 #[cfg(feature = "defmt")]
 impl defmt::Format for Dllcr {
     fn format(&self, f: defmt::Formatter) {
-        defmt :: write ! (f , "Dllcr {{ en: {=bool:?}, sw: {=bool:?}, stg: {=u8:?}, xtalin_en: {=bool:?}, mode48m_en: {=bool:?}, ldo_vref: {=u8:?}, in_div2_en: {=bool:?}, out_div2_en: {=bool:?}, mcu_prchg_en: {=bool:?}, mcu_prchg: {=bool:?}, prchg_en: {=bool:?}, prchg_ext: {=bool:?}, vst_sel: {=bool:?}, bypass: {=bool:?}, dtest_en: {=bool:?}, dtest_tr: {=u8:?}, pu_dly: {=u8:?}, lock_dly: {=u8:?}, ready: {=bool:?} }}" , self . en () , self . sw () , self . stg () , self . xtalin_en () , self . mode48m_en () , self . ldo_vref () , self . in_div2_en () , self . out_div2_en () , self . mcu_prchg_en () , self . mcu_prchg () , self . prchg_en () , self . prchg_ext () , self . vst_sel () , self . bypass () , self . dtest_en () , self . dtest_tr () , self . pu_dly () , self . lock_dly () , self . ready ())
+        defmt :: write ! (f , "Dllcr {{ en: {=bool:?}, sw: {=bool:?}, stg: {:?}, xtalin_en: {=bool:?}, mode48m_en: {=bool:?}, ldo_vref: {=u8:?}, in_div2_en: {=bool:?}, out_div2_en: {=bool:?}, mcu_prchg_en: {=bool:?}, mcu_prchg: {=bool:?}, prchg_en: {=bool:?}, prchg_ext: {=bool:?}, vst_sel: {=bool:?}, bypass: {=bool:?}, dtest_en: {=bool:?}, dtest_tr: {=u8:?}, pu_dly: {=u8:?}, lock_dly: {=u8:?}, ready: {=bool:?} }}" , self . en () , self . sw () , self . stg () , self . xtalin_en () , self . mode48m_en () , self . ldo_vref () , self . in_div2_en () , self . out_div2_en () , self . mcu_prchg_en () , self . mcu_prchg () , self . prchg_en () , self . prchg_ext () , self . vst_sel () , self . bypass () , self . dtest_en () , self . dtest_tr () , self . pu_dly () , self . lock_dly () , self . ready ())
     }
 }
 #[doc = "Deep WFI mode Clock Configuration Register"]
@@ -778,26 +778,26 @@ impl Dwcfgr {
     #[doc = "pclk_hpsys = hclk_hpsys / (2^PDIV1) during deep wfi"]
     #[must_use]
     #[inline(always)]
-    pub const fn pdiv1(&self) -> u8 {
+    pub const fn pdiv1(&self) -> super::vals::Pdiv {
         let val = (self.0 >> 8usize) & 0x07;
-        val as u8
+        super::vals::Pdiv::from_bits(val as u8)
     }
     #[doc = "pclk_hpsys = hclk_hpsys / (2^PDIV1) during deep wfi"]
     #[inline(always)]
-    pub const fn set_pdiv1(&mut self, val: u8) {
-        self.0 = (self.0 & !(0x07 << 8usize)) | (((val as u32) & 0x07) << 8usize);
+    pub const fn set_pdiv1(&mut self, val: super::vals::Pdiv) {
+        self.0 = (self.0 & !(0x07 << 8usize)) | (((val.to_bits() as u32) & 0x07) << 8usize);
     }
     #[doc = "pclk2_hpsys = hclk_hpsys / (2^PDIV2) during deep wfi"]
     #[must_use]
     #[inline(always)]
-    pub const fn pdiv2(&self) -> u8 {
+    pub const fn pdiv2(&self) -> super::vals::Pdiv {
         let val = (self.0 >> 12usize) & 0x07;
-        val as u8
+        super::vals::Pdiv::from_bits(val as u8)
     }
     #[doc = "pclk2_hpsys = hclk_hpsys / (2^PDIV2) during deep wfi"]
     #[inline(always)]
-    pub const fn set_pdiv2(&mut self, val: u8) {
-        self.0 = (self.0 & !(0x07 << 12usize)) | (((val as u32) & 0x07) << 12usize);
+    pub const fn set_pdiv2(&mut self, val: super::vals::Pdiv) {
+        self.0 = (self.0 & !(0x07 << 12usize)) | (((val.to_bits() as u32) & 0x07) << 12usize);
     }
     #[doc = "enable PDIV1, PDIV2 and HDIV reconfiguration during deep wfi"]
     #[must_use]
@@ -814,26 +814,26 @@ impl Dwcfgr {
     #[doc = "select clk_hpsys source during deep WFI 0 - clk_hrc48; 1 - clk_hxt48; 2 - RSVD; 3 - clk_dll1"]
     #[must_use]
     #[inline(always)]
-    pub const fn sel_sys(&self) -> u8 {
+    pub const fn sel_sys(&self) -> super::vals::Sysclk {
         let val = (self.0 >> 16usize) & 0x03;
-        val as u8
+        super::vals::Sysclk::from_bits(val as u8)
     }
     #[doc = "select clk_hpsys source during deep WFI 0 - clk_hrc48; 1 - clk_hxt48; 2 - RSVD; 3 - clk_dll1"]
     #[inline(always)]
-    pub const fn set_sel_sys(&mut self, val: u8) {
-        self.0 = (self.0 & !(0x03 << 16usize)) | (((val as u32) & 0x03) << 16usize);
+    pub const fn set_sel_sys(&mut self, val: super::vals::Sysclk) {
+        self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
     }
     #[doc = "select clk_hpsys source during deep WFI 0 - selected by SEL_SYS; 1 - clk_wdt"]
     #[must_use]
     #[inline(always)]
-    pub const fn sel_sys_lp(&self) -> bool {
+    pub const fn sel_sys_lp(&self) -> super::vals::mux::Lpsel {
         let val = (self.0 >> 18usize) & 0x01;
-        val != 0
+        super::vals::mux::Lpsel::from_bits(val as u8)
     }
     #[doc = "select clk_hpsys source during deep WFI 0 - selected by SEL_SYS; 1 - clk_wdt"]
     #[inline(always)]
-    pub const fn set_sel_sys_lp(&mut self, val: bool) {
-        self.0 = (self.0 & !(0x01 << 18usize)) | (((val as u32) & 0x01) << 18usize);
+    pub const fn set_sel_sys_lp(&mut self, val: super::vals::mux::Lpsel) {
+        self.0 = (self.0 & !(0x01 << 18usize)) | (((val.to_bits() as u32) & 0x01) << 18usize);
     }
     #[doc = "for debug only"]
     #[must_use]
@@ -909,7 +909,7 @@ impl core::fmt::Debug for Dwcfgr {
 #[cfg(feature = "defmt")]
 impl defmt::Format for Dwcfgr {
     fn format(&self, f: defmt::Formatter) {
-        defmt :: write ! (f , "Dwcfgr {{ hdiv: {=u8:?}, pdiv1: {=u8:?}, pdiv2: {=u8:?}, div_en: {=bool:?}, sel_sys: {=u8:?}, sel_sys_lp: {=bool:?}, dll1_out_en: {=bool:?}, dll1_out_rstb: {=bool:?}, dll2_out_en: {=bool:?}, dll2_out_rstb: {=bool:?} }}" , self . hdiv () , self . pdiv1 () , self . pdiv2 () , self . div_en () , self . sel_sys () , self . sel_sys_lp () , self . dll1_out_en () , self . dll1_out_rstb () , self . dll2_out_en () , self . dll2_out_rstb ())
+        defmt :: write ! (f , "Dwcfgr {{ hdiv: {=u8:?}, pdiv1: {:?}, pdiv2: {:?}, div_en: {=bool:?}, sel_sys: {:?}, sel_sys_lp: {:?}, dll1_out_en: {=bool:?}, dll1_out_rstb: {=bool:?}, dll2_out_en: {=bool:?}, dll2_out_rstb: {=bool:?} }}" , self . hdiv () , self . pdiv1 () , self . pdiv2 () , self . div_en () , self . sel_sys () , self . sel_sys_lp () , self . dll1_out_en () , self . dll1_out_rstb () , self . dll2_out_en () , self . dll2_out_rstb ())
     }
 }
 #[doc = "Enable Clear Register 1"]

--- a/src/sf32lb52x/hpsys_rcc/vals.rs
+++ b/src/sf32lb52x/hpsys_rcc/vals.rs
@@ -1,44 +1,121 @@
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum SelPeri {
-    Hrc48 = 0x0,
-    Hxt48 = 0x01,
+pub enum Dllstg {
+    #[doc = "Multiply by 1 (24 MHz)"]
+    Mul1 = 0x0,
+    #[doc = "Multiply by 2 (48 MHz)"]
+    Mul2 = 0x01,
+    #[doc = "Multiply by 3 (72 MHz)"]
+    Mul3 = 0x02,
+    #[doc = "Multiply by 4 (96 MHz)"]
+    Mul4 = 0x03,
+    #[doc = "Multiply by 5 (120 MHz)"]
+    Mul5 = 0x04,
+    #[doc = "Multiply by 6 (144 MHz)"]
+    Mul6 = 0x05,
+    #[doc = "Multiply by 7 (168 MHz)"]
+    Mul7 = 0x06,
+    #[doc = "Multiply by 8 (192 MHz)"]
+    Mul8 = 0x07,
+    #[doc = "Multiply by 9 (216 MHz)"]
+    Mul9 = 0x08,
+    #[doc = "Multiply by 10 (240 MHz)"]
+    Mul10 = 0x09,
+    #[doc = "Multiply by 11 (264 MHz)"]
+    Mul11 = 0x0a,
+    #[doc = "Multiply by 12 (288 MHz)"]
+    Mul12 = 0x0b,
+    #[doc = "Multiply by 13 (312 MHz)"]
+    Mul13 = 0x0c,
+    #[doc = "Multiply by 14 (336 MHz)"]
+    Mul14 = 0x0d,
+    #[doc = "Multiply by 15 (360 MHz)"]
+    Mul15 = 0x0e,
+    #[doc = "Multiply by 16 (384 MHz)"]
+    Mul16 = 0x0f,
 }
-impl SelPeri {
+impl Dllstg {
     #[inline(always)]
-    pub const fn from_bits(val: u8) -> SelPeri {
-        unsafe { core::mem::transmute(val & 0x01) }
+    pub const fn from_bits(val: u8) -> Dllstg {
+        unsafe { core::mem::transmute(val & 0x0f) }
     }
     #[inline(always)]
     pub const fn to_bits(self) -> u8 {
         unsafe { core::mem::transmute(self) }
     }
 }
-impl From<u8> for SelPeri {
+impl From<u8> for Dllstg {
     #[inline(always)]
-    fn from(val: u8) -> SelPeri {
-        SelPeri::from_bits(val)
+    fn from(val: u8) -> Dllstg {
+        Dllstg::from_bits(val)
     }
 }
-impl From<SelPeri> for u8 {
+impl From<Dllstg> for u8 {
     #[inline(always)]
-    fn from(val: SelPeri) -> u8 {
-        SelPeri::to_bits(val)
+    fn from(val: Dllstg) -> u8 {
+        Dllstg::to_bits(val)
     }
 }
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum SelSys {
+pub enum Pdiv {
+    #[doc = "Divide by 1"]
+    Div1 = 0x0,
+    #[doc = "Divide by 2"]
+    Div2 = 0x01,
+    #[doc = "Divide by 4"]
+    Div4 = 0x02,
+    #[doc = "Divide by 8"]
+    Div8 = 0x03,
+    #[doc = "Divide by 16"]
+    Div16 = 0x04,
+    #[doc = "Divide by 32"]
+    Div32 = 0x05,
+    #[doc = "Divide by 64"]
+    Div64 = 0x06,
+    #[doc = "Divide by 128"]
+    Div128 = 0x07,
+}
+impl Pdiv {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> Pdiv {
+        unsafe { core::mem::transmute(val & 0x07) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for Pdiv {
+    #[inline(always)]
+    fn from(val: u8) -> Pdiv {
+        Pdiv::from_bits(val)
+    }
+}
+impl From<Pdiv> for u8 {
+    #[inline(always)]
+    fn from(val: Pdiv) -> u8 {
+        Pdiv::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Sysclk {
+    #[doc = "48MHz internal RC oscillator"]
     Hrc48 = 0x0,
+    #[doc = "48MHz external crystal"]
     Hxt48 = 0x01,
+    #[doc = "96MHz doubler (not implemented)"]
     Dbl96 = 0x02,
+    #[doc = "DLL1 output"]
     Dll1 = 0x03,
 }
-impl SelSys {
+impl Sysclk {
     #[inline(always)]
-    pub const fn from_bits(val: u8) -> SelSys {
+    pub const fn from_bits(val: u8) -> Sysclk {
         unsafe { core::mem::transmute(val & 0x03) }
     }
     #[inline(always)]
@@ -46,75 +123,16 @@ impl SelSys {
         unsafe { core::mem::transmute(self) }
     }
 }
-impl From<u8> for SelSys {
+impl From<u8> for Sysclk {
     #[inline(always)]
-    fn from(val: u8) -> SelSys {
-        SelSys::from_bits(val)
+    fn from(val: u8) -> Sysclk {
+        Sysclk::from_bits(val)
     }
 }
-impl From<SelSys> for u8 {
+impl From<Sysclk> for u8 {
     #[inline(always)]
-    fn from(val: SelSys) -> u8 {
-        SelSys::to_bits(val)
+    fn from(val: Sysclk) -> u8 {
+        Sysclk::to_bits(val)
     }
 }
-#[repr(u8)]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum SelTick {
-    ClkRtc = 0x0,
-    _RESERVED_1 = 0x01,
-    Hrc48 = 0x02,
-    Hxt48 = 0x03,
-}
-impl SelTick {
-    #[inline(always)]
-    pub const fn from_bits(val: u8) -> SelTick {
-        unsafe { core::mem::transmute(val & 0x03) }
-    }
-    #[inline(always)]
-    pub const fn to_bits(self) -> u8 {
-        unsafe { core::mem::transmute(self) }
-    }
-}
-impl From<u8> for SelTick {
-    #[inline(always)]
-    fn from(val: u8) -> SelTick {
-        SelTick::from_bits(val)
-    }
-}
-impl From<SelTick> for u8 {
-    #[inline(always)]
-    fn from(val: SelTick) -> u8 {
-        SelTick::to_bits(val)
-    }
-}
-#[repr(u8)]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum SelUsbc {
-    ClkSys = 0x0,
-    Dll2 = 0x01,
-}
-impl SelUsbc {
-    #[inline(always)]
-    pub const fn from_bits(val: u8) -> SelUsbc {
-        unsafe { core::mem::transmute(val & 0x01) }
-    }
-    #[inline(always)]
-    pub const fn to_bits(self) -> u8 {
-        unsafe { core::mem::transmute(self) }
-    }
-}
-impl From<u8> for SelUsbc {
-    #[inline(always)]
-    fn from(val: u8) -> SelUsbc {
-        SelUsbc::from_bits(val)
-    }
-}
-impl From<SelUsbc> for u8 {
-    #[inline(always)]
-    fn from(val: SelUsbc) -> u8 {
-        SelUsbc::to_bits(val)
-    }
-}
+pub mod mux;

--- a/src/sf32lb52x/hpsys_rcc/vals/mux.rs
+++ b/src/sf32lb52x/hpsys_rcc/vals/mux.rs
@@ -1,0 +1,223 @@
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Lpsel {
+    #[doc = "Use clock selected by SEL_SYS"]
+    SelSys = 0x0,
+    #[doc = "Use WDT clock (low power)"]
+    Wdt = 0x01,
+}
+impl Lpsel {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> Lpsel {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for Lpsel {
+    #[inline(always)]
+    fn from(val: u8) -> Lpsel {
+        Lpsel::from_bits(val)
+    }
+}
+impl From<Lpsel> for u8 {
+    #[inline(always)]
+    fn from(val: Lpsel) -> u8 {
+        Lpsel::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Mpisel {
+    #[doc = "Use clk_peri_hpsys"]
+    Peri = 0x0,
+    #[doc = "Use DLL1 clock"]
+    Dll1 = 0x01,
+    #[doc = "Use DLL2 clock"]
+    Dll2 = 0x02,
+    _RESERVED_3 = 0x03,
+}
+impl Mpisel {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> Mpisel {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for Mpisel {
+    #[inline(always)]
+    fn from(val: u8) -> Mpisel {
+        Mpisel::from_bits(val)
+    }
+}
+impl From<Mpisel> for u8 {
+    #[inline(always)]
+    fn from(val: Mpisel) -> u8 {
+        Mpisel::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Perisel {
+    #[doc = "Use HRC48 for peripheral clock"]
+    Hrc48 = 0x0,
+    #[doc = "Use HXT48 for peripheral clock"]
+    Hxt48 = 0x01,
+}
+impl Perisel {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> Perisel {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for Perisel {
+    #[inline(always)]
+    fn from(val: u8) -> Perisel {
+        Perisel::from_bits(val)
+    }
+}
+impl From<Perisel> for u8 {
+    #[inline(always)]
+    fn from(val: Perisel) -> u8 {
+        Perisel::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Rtcsel {
+    #[doc = "Use LRC10K (100 kHz)"]
+    Lrc10 = 0x0,
+    #[doc = "Use LXT32K (32.768 kHz)"]
+    Lxt32 = 0x01,
+}
+impl Rtcsel {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> Rtcsel {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for Rtcsel {
+    #[inline(always)]
+    fn from(val: u8) -> Rtcsel {
+        Rtcsel::from_bits(val)
+    }
+}
+impl From<Rtcsel> for u8 {
+    #[inline(always)]
+    fn from(val: Rtcsel) -> u8 {
+        Rtcsel::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Ticksel {
+    #[doc = "Use RTC clock"]
+    ClkRtc = 0x0,
+    _RESERVED_1 = 0x01,
+    #[doc = "Use HRC48"]
+    Hrc48 = 0x02,
+    #[doc = "Use HXT48"]
+    Hxt48 = 0x03,
+}
+impl Ticksel {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> Ticksel {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for Ticksel {
+    #[inline(always)]
+    fn from(val: u8) -> Ticksel {
+        Ticksel::from_bits(val)
+    }
+}
+impl From<Ticksel> for u8 {
+    #[inline(always)]
+    fn from(val: Ticksel) -> u8 {
+        Ticksel::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Usbsel {
+    #[doc = "Use system clock"]
+    Sysclk = 0x0,
+    #[doc = "Use DLL2 clock"]
+    Dll2 = 0x01,
+}
+impl Usbsel {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> Usbsel {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for Usbsel {
+    #[inline(always)]
+    fn from(val: u8) -> Usbsel {
+        Usbsel::from_bits(val)
+    }
+}
+impl From<Usbsel> for u8 {
+    #[inline(always)]
+    fn from(val: Usbsel) -> u8 {
+        Usbsel::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Wdtsel {
+    #[doc = "Use LRC10K (100 kHz)"]
+    Lrc10 = 0x0,
+    #[doc = "Use LRC32K (32 kHz)"]
+    Lrc32 = 0x01,
+}
+impl Wdtsel {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> Wdtsel {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for Wdtsel {
+    #[inline(always)]
+    fn from(val: u8) -> Wdtsel {
+        Wdtsel::from_bits(val)
+    }
+}
+impl From<Wdtsel> for u8 {
+    #[inline(always)]
+    fn from(val: Wdtsel) -> u8 {
+        Wdtsel::to_bits(val)
+    }
+}

--- a/src/sf32lb52x/lpsys_rcc/regs.rs
+++ b/src/sf32lb52x/lpsys_rcc/regs.rs
@@ -6,50 +6,50 @@ impl Cfgr {
     #[doc = "hclk_lpsys = clk_lpsys / HDIV if HDIV=0, hclk_lpsys = clk_lpsys"]
     #[must_use]
     #[inline(always)]
-    pub const fn hdiv1(&self) -> u8 {
+    pub const fn hdiv1(&self) -> super::vals::Hdiv {
         let val = (self.0 >> 0usize) & 0x3f;
-        val as u8
+        super::vals::Hdiv::from_bits(val as u8)
     }
     #[doc = "hclk_lpsys = clk_lpsys / HDIV if HDIV=0, hclk_lpsys = clk_lpsys"]
     #[inline(always)]
-    pub const fn set_hdiv1(&mut self, val: u8) {
-        self.0 = (self.0 & !(0x3f << 0usize)) | (((val as u32) & 0x3f) << 0usize);
+    pub const fn set_hdiv1(&mut self, val: super::vals::Hdiv) {
+        self.0 = (self.0 & !(0x3f << 0usize)) | (((val.to_bits() as u32) & 0x3f) << 0usize);
     }
     #[doc = "pclk1_lpsys = hclk_lpsys / (2^PDIV1), by default divided by 2"]
     #[must_use]
     #[inline(always)]
-    pub const fn pdiv1(&self) -> u8 {
+    pub const fn pdiv1(&self) -> super::vals::Pdiv {
         let val = (self.0 >> 8usize) & 0x07;
-        val as u8
+        super::vals::Pdiv::from_bits(val as u8)
     }
     #[doc = "pclk1_lpsys = hclk_lpsys / (2^PDIV1), by default divided by 2"]
     #[inline(always)]
-    pub const fn set_pdiv1(&mut self, val: u8) {
-        self.0 = (self.0 & !(0x07 << 8usize)) | (((val as u32) & 0x07) << 8usize);
+    pub const fn set_pdiv1(&mut self, val: super::vals::Pdiv) {
+        self.0 = (self.0 & !(0x07 << 8usize)) | (((val.to_bits() as u32) & 0x07) << 8usize);
     }
     #[doc = "pclk2_lpsys = hclk_lpsys / (2^PDIV2), by default divided by 32"]
     #[must_use]
     #[inline(always)]
-    pub const fn pdiv2(&self) -> u8 {
+    pub const fn pdiv2(&self) -> super::vals::Pdiv {
         let val = (self.0 >> 12usize) & 0x07;
-        val as u8
+        super::vals::Pdiv::from_bits(val as u8)
     }
     #[doc = "pclk2_lpsys = hclk_lpsys / (2^PDIV2), by default divided by 32"]
     #[inline(always)]
-    pub const fn set_pdiv2(&mut self, val: u8) {
-        self.0 = (self.0 & !(0x07 << 12usize)) | (((val as u32) & 0x07) << 12usize);
+    pub const fn set_pdiv2(&mut self, val: super::vals::Pdiv) {
+        self.0 = (self.0 & !(0x07 << 12usize)) | (((val.to_bits() as u32) & 0x07) << 12usize);
     }
     #[doc = "MAC clock divider MACCLK = hclk_lpsys / MACDIV"]
     #[must_use]
     #[inline(always)]
-    pub const fn macdiv(&self) -> u8 {
+    pub const fn macdiv(&self) -> super::vals::Macdiv {
         let val = (self.0 >> 16usize) & 0x0f;
-        val as u8
+        super::vals::Macdiv::from_bits(val as u8)
     }
     #[doc = "MAC clock divider MACCLK = hclk_lpsys / MACDIV"]
     #[inline(always)]
-    pub const fn set_macdiv(&mut self, val: u8) {
-        self.0 = (self.0 & !(0x0f << 16usize)) | (((val as u32) & 0x0f) << 16usize);
+    pub const fn set_macdiv(&mut self, val: super::vals::Macdiv) {
+        self.0 = (self.0 & !(0x0f << 16usize)) | (((val.to_bits() as u32) & 0x0f) << 16usize);
     }
     #[doc = "clock frequency of MAC clock"]
     #[must_use]
@@ -97,7 +97,7 @@ impl core::fmt::Debug for Cfgr {
 #[cfg(feature = "defmt")]
 impl defmt::Format for Cfgr {
     fn format(&self, f: defmt::Formatter) {
-        defmt :: write ! (f , "Cfgr {{ hdiv1: {=u8:?}, pdiv1: {=u8:?}, pdiv2: {=u8:?}, macdiv: {=u8:?}, macfreq: {=u8:?}, tickdiv: {=u8:?} }}" , self . hdiv1 () , self . pdiv1 () , self . pdiv2 () , self . macdiv () , self . macfreq () , self . tickdiv ())
+        defmt :: write ! (f , "Cfgr {{ hdiv1: {:?}, pdiv1: {:?}, pdiv2: {:?}, macdiv: {:?}, macfreq: {=u8:?}, tickdiv: {=u8:?} }}" , self . hdiv1 () , self . pdiv1 () , self . pdiv2 () , self . macdiv () , self . macfreq () , self . tickdiv ())
     }
 }
 #[doc = "Clock Select Register"]
@@ -108,49 +108,49 @@ impl Csr {
     #[doc = "select clk_lpsys source 0 - clk_hrc48; 1 - clk_hxt48"]
     #[must_use]
     #[inline(always)]
-    pub const fn sel_sys(&self) -> super::vals::SelSys {
+    pub const fn sel_sys(&self) -> super::vals::Sysclk {
         let val = (self.0 >> 0usize) & 0x01;
-        super::vals::SelSys::from_bits(val as u8)
+        super::vals::Sysclk::from_bits(val as u8)
     }
     #[doc = "select clk_lpsys source 0 - clk_hrc48; 1 - clk_hxt48"]
     #[inline(always)]
-    pub const fn set_sel_sys(&mut self, val: super::vals::SelSys) {
+    pub const fn set_sel_sys(&mut self, val: super::vals::Sysclk) {
         self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
     }
     #[doc = "select clk_lpsys source 0 - selected by SEL_SYS; 1 - clk_wdt"]
     #[must_use]
     #[inline(always)]
-    pub const fn sel_sys_lp(&self) -> bool {
+    pub const fn sel_sys_lp(&self) -> super::vals::mux::Lpsel {
         let val = (self.0 >> 2usize) & 0x01;
-        val != 0
+        super::vals::mux::Lpsel::from_bits(val as u8)
     }
     #[doc = "select clk_lpsys source 0 - selected by SEL_SYS; 1 - clk_wdt"]
     #[inline(always)]
-    pub const fn set_sel_sys_lp(&mut self, val: bool) {
-        self.0 = (self.0 & !(0x01 << 2usize)) | (((val as u32) & 0x01) << 2usize);
+    pub const fn set_sel_sys_lp(&mut self, val: super::vals::mux::Lpsel) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val.to_bits() as u32) & 0x01) << 2usize);
     }
     #[doc = "select clk_peri_lpsys source 0 - clk_hrc48; 1 - clk_hxt48"]
     #[must_use]
     #[inline(always)]
-    pub const fn sel_peri(&self) -> super::vals::SelPeri {
+    pub const fn sel_peri(&self) -> super::vals::mux::Perisel {
         let val = (self.0 >> 4usize) & 0x01;
-        super::vals::SelPeri::from_bits(val as u8)
+        super::vals::mux::Perisel::from_bits(val as u8)
     }
     #[doc = "select clk_peri_lpsys source 0 - clk_hrc48; 1 - clk_hxt48"]
     #[inline(always)]
-    pub const fn set_sel_peri(&mut self, val: super::vals::SelPeri) {
+    pub const fn set_sel_peri(&mut self, val: super::vals::mux::Perisel) {
         self.0 = (self.0 & !(0x01 << 4usize)) | (((val.to_bits() as u32) & 0x01) << 4usize);
     }
     #[doc = "select clock source for systick reference 0 - clk_rtc; 1 - reserved; 2 - clk_hrc48; 3 - clk_hxt48"]
     #[must_use]
     #[inline(always)]
-    pub const fn sel_tick(&self) -> super::vals::SelTick {
+    pub const fn sel_tick(&self) -> super::vals::mux::Ticksel {
         let val = (self.0 >> 5usize) & 0x03;
-        super::vals::SelTick::from_bits(val as u8)
+        super::vals::mux::Ticksel::from_bits(val as u8)
     }
     #[doc = "select clock source for systick reference 0 - clk_rtc; 1 - reserved; 2 - clk_hrc48; 3 - clk_hxt48"]
     #[inline(always)]
-    pub const fn set_sel_tick(&mut self, val: super::vals::SelTick) {
+    pub const fn set_sel_tick(&mut self, val: super::vals::mux::Ticksel) {
         self.0 = (self.0 & !(0x03 << 5usize)) | (((val.to_bits() as u32) & 0x03) << 5usize);
     }
 }
@@ -175,7 +175,7 @@ impl defmt::Format for Csr {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "Csr {{ sel_sys: {:?}, sel_sys_lp: {=bool:?}, sel_peri: {:?}, sel_tick: {:?} }}",
+            "Csr {{ sel_sys: {:?}, sel_sys_lp: {:?}, sel_peri: {:?}, sel_tick: {:?} }}",
             self.sel_sys(),
             self.sel_sys_lp(),
             self.sel_peri(),

--- a/src/sf32lb52x/lpsys_rcc/vals.rs
+++ b/src/sf32lb52x/lpsys_rcc/vals.rs
@@ -1,13 +1,175 @@
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum SelPeri {
+pub enum Hdiv {
+    #[doc = "Divide by 1"]
+    Div1 = 0x0,
+    #[doc = "Divide by 2"]
+    Div2 = 0x01,
+    #[doc = "Divide by 3"]
+    Div3 = 0x02,
+    #[doc = "Divide by 4"]
+    Div4 = 0x03,
+    #[doc = "Divide by 5"]
+    Div5 = 0x04,
+    #[doc = "Divide by 6"]
+    Div6 = 0x05,
+    #[doc = "Divide by 7"]
+    Div7 = 0x06,
+    #[doc = "Divide by 8"]
+    Div8 = 0x07,
+    #[doc = "Divide by 9"]
+    Div9 = 0x08,
+    #[doc = "Divide by 10"]
+    Div10 = 0x09,
+    #[doc = "Divide by 11"]
+    Div11 = 0x0a,
+    #[doc = "Divide by 12"]
+    Div12 = 0x0b,
+    #[doc = "Divide by 13"]
+    Div13 = 0x0c,
+    #[doc = "Divide by 14"]
+    Div14 = 0x0d,
+    #[doc = "Divide by 15"]
+    Div15 = 0x0e,
+    #[doc = "Divide by 16"]
+    Div16 = 0x0f,
+}
+impl Hdiv {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> Hdiv {
+        unsafe { core::mem::transmute(val & 0x0f) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for Hdiv {
+    #[inline(always)]
+    fn from(val: u8) -> Hdiv {
+        Hdiv::from_bits(val)
+    }
+}
+impl From<Hdiv> for u8 {
+    #[inline(always)]
+    fn from(val: Hdiv) -> u8 {
+        Hdiv::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Macdiv {
+    _RESERVED_0 = 0x0,
+    #[doc = "Divide by 1"]
+    Div1 = 0x01,
+    #[doc = "Divide by 2"]
+    Div2 = 0x02,
+    #[doc = "Divide by 3"]
+    Div3 = 0x03,
+    #[doc = "Divide by 4"]
+    Div4 = 0x04,
+    #[doc = "Divide by 5"]
+    Div5 = 0x05,
+    #[doc = "Divide by 6"]
+    Div6 = 0x06,
+    #[doc = "Divide by 7"]
+    Div7 = 0x07,
+    #[doc = "Divide by 8"]
+    Div8 = 0x08,
+    #[doc = "Divide by 9"]
+    Div9 = 0x09,
+    #[doc = "Divide by 10"]
+    Div10 = 0x0a,
+    #[doc = "Divide by 11"]
+    Div11 = 0x0b,
+    #[doc = "Divide by 12"]
+    Div12 = 0x0c,
+    #[doc = "Divide by 13"]
+    Div13 = 0x0d,
+    #[doc = "Divide by 14"]
+    Div14 = 0x0e,
+    #[doc = "Divide by 15"]
+    Div15 = 0x0f,
+}
+impl Macdiv {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> Macdiv {
+        unsafe { core::mem::transmute(val & 0x0f) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for Macdiv {
+    #[inline(always)]
+    fn from(val: u8) -> Macdiv {
+        Macdiv::from_bits(val)
+    }
+}
+impl From<Macdiv> for u8 {
+    #[inline(always)]
+    fn from(val: Macdiv) -> u8 {
+        Macdiv::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Pdiv {
+    #[doc = "Divide by 1"]
+    Div1 = 0x0,
+    #[doc = "Divide by 2"]
+    Div2 = 0x01,
+    #[doc = "Divide by 4"]
+    Div4 = 0x02,
+    #[doc = "Divide by 8"]
+    Div8 = 0x03,
+    #[doc = "Divide by 16"]
+    Div16 = 0x04,
+    #[doc = "Divide by 32"]
+    Div32 = 0x05,
+    #[doc = "Divide by 64"]
+    Div64 = 0x06,
+    #[doc = "Divide by 128"]
+    Div128 = 0x07,
+}
+impl Pdiv {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> Pdiv {
+        unsafe { core::mem::transmute(val & 0x07) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for Pdiv {
+    #[inline(always)]
+    fn from(val: u8) -> Pdiv {
+        Pdiv::from_bits(val)
+    }
+}
+impl From<Pdiv> for u8 {
+    #[inline(always)]
+    fn from(val: Pdiv) -> u8 {
+        Pdiv::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Sysclk {
+    #[doc = "48MHz internal RC oscillator"]
     Hrc48 = 0x0,
+    #[doc = "48MHz external crystal"]
     Hxt48 = 0x01,
 }
-impl SelPeri {
+impl Sysclk {
     #[inline(always)]
-    pub const fn from_bits(val: u8) -> SelPeri {
+    pub const fn from_bits(val: u8) -> Sysclk {
         unsafe { core::mem::transmute(val & 0x01) }
     }
     #[inline(always)]
@@ -15,75 +177,16 @@ impl SelPeri {
         unsafe { core::mem::transmute(self) }
     }
 }
-impl From<u8> for SelPeri {
+impl From<u8> for Sysclk {
     #[inline(always)]
-    fn from(val: u8) -> SelPeri {
-        SelPeri::from_bits(val)
+    fn from(val: u8) -> Sysclk {
+        Sysclk::from_bits(val)
     }
 }
-impl From<SelPeri> for u8 {
+impl From<Sysclk> for u8 {
     #[inline(always)]
-    fn from(val: SelPeri) -> u8 {
-        SelPeri::to_bits(val)
+    fn from(val: Sysclk) -> u8 {
+        Sysclk::to_bits(val)
     }
 }
-#[repr(u8)]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum SelSys {
-    Hrc48 = 0x0,
-    Hxt48 = 0x01,
-}
-impl SelSys {
-    #[inline(always)]
-    pub const fn from_bits(val: u8) -> SelSys {
-        unsafe { core::mem::transmute(val & 0x01) }
-    }
-    #[inline(always)]
-    pub const fn to_bits(self) -> u8 {
-        unsafe { core::mem::transmute(self) }
-    }
-}
-impl From<u8> for SelSys {
-    #[inline(always)]
-    fn from(val: u8) -> SelSys {
-        SelSys::from_bits(val)
-    }
-}
-impl From<SelSys> for u8 {
-    #[inline(always)]
-    fn from(val: SelSys) -> u8 {
-        SelSys::to_bits(val)
-    }
-}
-#[repr(u8)]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum SelTick {
-    ClkRtc = 0x0,
-    _RESERVED_1 = 0x01,
-    Hrc48 = 0x02,
-    Hxt48 = 0x03,
-}
-impl SelTick {
-    #[inline(always)]
-    pub const fn from_bits(val: u8) -> SelTick {
-        unsafe { core::mem::transmute(val & 0x03) }
-    }
-    #[inline(always)]
-    pub const fn to_bits(self) -> u8 {
-        unsafe { core::mem::transmute(self) }
-    }
-}
-impl From<u8> for SelTick {
-    #[inline(always)]
-    fn from(val: u8) -> SelTick {
-        SelTick::from_bits(val)
-    }
-}
-impl From<SelTick> for u8 {
-    #[inline(always)]
-    fn from(val: SelTick) -> u8 {
-        SelTick::to_bits(val)
-    }
-}
+pub mod mux;

--- a/src/sf32lb52x/lpsys_rcc/vals/mux.rs
+++ b/src/sf32lb52x/lpsys_rcc/vals/mux.rs
@@ -1,0 +1,96 @@
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Lpsel {
+    #[doc = "Use clock selected by SEL_SYS"]
+    SelSys = 0x0,
+    #[doc = "Use WDT clock (low power)"]
+    Wdt = 0x01,
+}
+impl Lpsel {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> Lpsel {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for Lpsel {
+    #[inline(always)]
+    fn from(val: u8) -> Lpsel {
+        Lpsel::from_bits(val)
+    }
+}
+impl From<Lpsel> for u8 {
+    #[inline(always)]
+    fn from(val: Lpsel) -> u8 {
+        Lpsel::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Perisel {
+    #[doc = "Use HRC48 for peripheral clock"]
+    Hrc48 = 0x0,
+    #[doc = "Use HXT48 for peripheral clock"]
+    Hxt48 = 0x01,
+}
+impl Perisel {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> Perisel {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for Perisel {
+    #[inline(always)]
+    fn from(val: u8) -> Perisel {
+        Perisel::from_bits(val)
+    }
+}
+impl From<Perisel> for u8 {
+    #[inline(always)]
+    fn from(val: Perisel) -> u8 {
+        Perisel::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Ticksel {
+    #[doc = "Use RTC clock"]
+    ClkRtc = 0x0,
+    _RESERVED_1 = 0x01,
+    #[doc = "Use HRC48"]
+    Hrc48 = 0x02,
+    #[doc = "Use HXT48"]
+    Hxt48 = 0x03,
+}
+impl Ticksel {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> Ticksel {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for Ticksel {
+    #[inline(always)]
+    fn from(val: u8) -> Ticksel {
+        Ticksel::from_bits(val)
+    }
+}
+impl From<Ticksel> for u8 {
+    #[inline(always)]
+    fn from(val: Ticksel) -> u8 {
+        Ticksel::to_bits(val)
+    }
+}

--- a/src/sf32lb52x/pmuc/regs.rs
+++ b/src/sf32lb52x/pmuc/regs.rs
@@ -1561,14 +1561,14 @@ impl Cr {
     #[doc = "LP clock for watchdog and FSM. 0 - LRC10, 1 - LRC32"]
     #[must_use]
     #[inline(always)]
-    pub const fn sel_lpclk(&self) -> bool {
+    pub const fn sel_lpclk(&self) -> super::super::hpsys_rcc::vals::mux::Wdtsel {
         let val = (self.0 >> 0usize) & 0x01;
-        val != 0
+        super::super::hpsys_rcc::vals::mux::Wdtsel::from_bits(val as u8)
     }
     #[doc = "LP clock for watchdog and FSM. 0 - LRC10, 1 - LRC32"]
     #[inline(always)]
-    pub const fn set_sel_lpclk(&mut self, val: bool) {
-        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    pub const fn set_sel_lpclk(&mut self, val: super::super::hpsys_rcc::vals::mux::Wdtsel) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
     }
     #[doc = "Write 1 to enter hibernate mode; write 0 to clear when exit from hibernate"]
     #[must_use]
@@ -1676,7 +1676,7 @@ impl core::fmt::Debug for Cr {
 #[cfg(feature = "defmt")]
 impl defmt::Format for Cr {
     fn format(&self, f: defmt::Formatter) {
-        defmt :: write ! (f , "Cr {{ sel_lpclk: {=bool:?}, hiber_en: {=bool:?}, reboot: {=bool:?}, pin_ret: {=bool:?}, pin0_mode: {=u8:?}, pin1_mode: {=u8:?}, pin0_sel: {=u8:?}, pin1_sel: {=u8:?} }}" , self . sel_lpclk () , self . hiber_en () , self . reboot () , self . pin_ret () , self . pin0_mode () , self . pin1_mode () , self . pin0_sel () , self . pin1_sel ())
+        defmt :: write ! (f , "Cr {{ sel_lpclk: {:?}, hiber_en: {=bool:?}, reboot: {=bool:?}, pin_ret: {=bool:?}, pin0_mode: {=u8:?}, pin1_mode: {=u8:?}, pin0_sel: {=u8:?}, pin1_sel: {=u8:?} }}" , self . sel_lpclk () , self . hiber_en () , self . reboot () , self . pin_ret () , self . pin0_mode () , self . pin1_mode () , self . pin0_sel () , self . pin1_sel ())
     }
 }
 #[doc = "DBL96 Calibration Register"]

--- a/transform/common/rcc.yaml
+++ b/transform/common/rcc.yaml
@@ -12,52 +12,6 @@ transforms:
       ir:
         # HPSYS_RCC enums
 
-        # CFGR.PDIV1, CFGR.PDIV2: APB prescaler (pclk = hclk / 2^PDIV)
-        enum/hpsys_rcc::vals::Pdiv:
-          bit_size: 3
-          variants:
-            - name: Div1
-              description: "Divide by 1"
-              value: 0
-            - name: Div2
-              description: "Divide by 2"
-              value: 1
-            - name: Div4
-              description: "Divide by 4"
-              value: 2
-            - name: Div8
-              description: "Divide by 8"
-              value: 3
-            - name: Div16
-              description: "Divide by 16"
-              value: 4
-            - name: Div32
-              description: "Divide by 32"
-              value: 5
-            - name: Div64
-              description: "Divide by 64"
-              value: 6
-            - name: Div128
-              description: "Divide by 128"
-              value: 7
-
-        # CSR.SEL_SYS, DWCFGR.SEL_SYS: System clock source
-        enum/hpsys_rcc::vals::Sysclk:
-          bit_size: 2
-          variants:
-            - name: Hrc48
-              description: "48MHz internal RC oscillator"
-              value: 0
-            - name: Hxt48
-              description: "48MHz external crystal"
-              value: 1
-            - name: Dbl96
-              description: "96MHz doubler (not implemented)"
-              value: 2
-            - name: Dll1
-              description: "DLL1 output"
-              value: 3
-
         # DLLCR.STG: DLL multiplication stage (freq = 24MHz * (stg + 1))
         enum/hpsys_rcc::vals::Dllstg:
           bit_size: 4
@@ -110,6 +64,52 @@ transforms:
             - name: Mul16
               description: "Multiply by 16 (384 MHz)"
               value: 15
+
+        # CFGR.PDIV1, CFGR.PDIV2: APB prescaler (pclk = hclk / 2^PDIV)
+        enum/hpsys_rcc::vals::Pdiv:
+          bit_size: 3
+          variants:
+            - name: Div1
+              description: "Divide by 1"
+              value: 0
+            - name: Div2
+              description: "Divide by 2"
+              value: 1
+            - name: Div4
+              description: "Divide by 4"
+              value: 2
+            - name: Div8
+              description: "Divide by 8"
+              value: 3
+            - name: Div16
+              description: "Divide by 16"
+              value: 4
+            - name: Div32
+              description: "Divide by 32"
+              value: 5
+            - name: Div64
+              description: "Divide by 64"
+              value: 6
+            - name: Div128
+              description: "Divide by 128"
+              value: 7
+
+        # CSR.SEL_SYS, DWCFGR.SEL_SYS: System clock source
+        enum/hpsys_rcc::vals::Sysclk:
+          bit_size: 2
+          variants:
+            - name: Hrc48
+              description: "48MHz internal RC oscillator"
+              value: 0
+            - name: Hxt48
+              description: "48MHz external crystal"
+              value: 1
+            - name: Dbl96
+              description: "96MHz doubler (not implemented)"
+              value: 2
+            - name: Dll1
+              description: "DLL1 output"
+              value: 3
 
         # CSR.SEL_SYS_LP, DWCFGR.SEL_SYS_LP: Low-power mode sysclk override
         enum/hpsys_rcc::vals::mux::Lpsel:
@@ -196,6 +196,11 @@ transforms:
 
   # Apply enums to HPSYS_RCC registers
   - !ModifyFieldsEnum
+      fieldset: hpsys_rcc::regs::Dllcr
+      field: stg
+      enum: hpsys_rcc::vals::Dllstg
+
+  - !ModifyFieldsEnum
       fieldset: hpsys_rcc::regs::Cfgr
       field: pdiv1
       enum: hpsys_rcc::vals::Pdiv
@@ -206,14 +211,39 @@ transforms:
       enum: hpsys_rcc::vals::Pdiv
 
   - !ModifyFieldsEnum
+      fieldset: hpsys_rcc::regs::Dwcfgr
+      field: pdiv1
+      enum: hpsys_rcc::vals::Pdiv
+
+  - !ModifyFieldsEnum
+      fieldset: hpsys_rcc::regs::Dwcfgr
+      field: pdiv2
+      enum: hpsys_rcc::vals::Pdiv
+
+  - !ModifyFieldsEnum
       fieldset: hpsys_rcc::regs::Csr
       field: sel_sys
       enum: hpsys_rcc::vals::Sysclk
 
   - !ModifyFieldsEnum
+      fieldset: hpsys_rcc::regs::Dwcfgr
+      field: sel_sys
+      enum: hpsys_rcc::vals::Sysclk
+
+  - !ModifyFieldsEnum
       fieldset: hpsys_rcc::regs::Csr
-      field: sel_peri
-      enum: hpsys_rcc::vals::mux::Perisel
+      field: sel_sys_lp
+      enum: hpsys_rcc::vals::mux::Lpsel
+
+  - !ModifyFieldsEnum
+      fieldset: hpsys_rcc::regs::Dwcfgr
+      field: sel_sys_lp
+      enum: hpsys_rcc::vals::mux::Lpsel
+
+  - !ModifyFieldsEnum
+      fieldset: hpsys_rcc::regs::Csr
+      field: sel_usbc
+      enum: hpsys_rcc::vals::mux::Usbsel
 
   - !ModifyFieldsEnum
       fieldset: hpsys_rcc::regs::Csr
@@ -222,8 +252,8 @@ transforms:
 
   - !ModifyFieldsEnum
       fieldset: hpsys_rcc::regs::Csr
-      field: sel_usbc
-      enum: hpsys_rcc::vals::mux::Usbsel
+      field: sel_peri
+      enum: hpsys_rcc::vals::mux::Perisel
 
   - !ModifyFieldsEnum
       fieldset: hpsys_rcc::regs::Csr
@@ -234,84 +264,6 @@ transforms:
       fieldset: hpsys_rcc::regs::Csr
       field: sel_mpi2
       enum: hpsys_rcc::vals::mux::Mpisel
-
-  - !ModifyFieldsEnum
-      fieldset: hpsys_rcc::regs::Csr
-      field: sel_sys_lp
-      enum: hpsys_rcc::vals::mux::Lpsel
-
-  - !ModifyFieldsEnum
-      fieldset: hpsys_rcc::regs::Dllcr
-      field: stg
-      enum: hpsys_rcc::vals::Dllstg
-
-  - !ModifyFieldsEnum
-      fieldset: hpsys_rcc::regs::Dwcfgr
-      field: sel_sys
-      enum: hpsys_rcc::vals::Sysclk
-
-  - !ModifyFieldsEnum
-      fieldset: hpsys_rcc::regs::Dwcfgr
-      field: sel_sys_lp
-      enum: hpsys_rcc::vals::mux::Lpsel
-
-  - !ModifyFieldsEnum
-      fieldset: hpsys_rcc::regs::Dwcfgr
-      field: pdiv1
-      enum: hpsys_rcc::vals::Pdiv
-
-  - !ModifyFieldsEnum
-      fieldset: hpsys_rcc::regs::Dwcfgr
-      field: pdiv2
-      enum: hpsys_rcc::vals::Pdiv
-
-  # LPSYS_RCC enums
-  - !Add
-      ir:
-        # CSR.SEL_SYS: System clock source
-        enum/lpsys_rcc::vals::SelSys:
-          bit_size: 1
-          variants:
-            - name: Hrc48
-              value: 0
-            - name: Hxt48
-              value: 1
-
-        # CSR.SEL_PERI: Peripheral clock source
-        enum/lpsys_rcc::vals::SelPeri:
-          bit_size: 1
-          variants:
-            - name: Hrc48
-              value: 0
-            - name: Hxt48
-              value: 1
-
-        # CSR.SEL_TICK: SysTick reference clock source
-        enum/lpsys_rcc::vals::SelTick:
-          bit_size: 2
-          variants:
-            - name: ClkRtc
-              value: 0
-            - name: Hrc48
-              value: 2
-            - name: Hxt48
-              value: 3
-
-  # Apply enums to LPSYS_RCC registers
-  - !ModifyFieldsEnum
-      fieldset: lpsys_rcc::regs::Csr
-      field: sel_sys
-      enum: lpsys_rcc::vals::SelSys
-
-  - !ModifyFieldsEnum
-      fieldset: lpsys_rcc::regs::Csr
-      field: sel_peri
-      enum: lpsys_rcc::vals::SelPeri
-
-  - !ModifyFieldsEnum
-      fieldset: lpsys_rcc::regs::Csr
-      field: sel_tick
-      enum: lpsys_rcc::vals::SelTick
 
   # Apply enums to PMUC registers
   - !ModifyFieldsEnum
@@ -324,3 +276,228 @@ transforms:
       fieldset: rtc::regs::Cr
       field: lpcksel
       enum: hpsys_rcc::vals::mux::Rtcsel
+
+  # LPSYS_RCC enums
+  - !Add
+      ir:
+        # CFGR.HDIV1: AHB prescaler (hclk_lpsys = clk_lpsys / (HDIV1 + 1))
+        # Note: HDIV1=0 means divide by 1
+        enum/lpsys_rcc::vals::Hdiv:
+          bit_size: 4
+          variants:
+            - name: Div1
+              description: "Divide by 1"
+              value: 0
+            - name: Div2
+              description: "Divide by 2"
+              value: 1
+            - name: Div3
+              description: "Divide by 3"
+              value: 2
+            - name: Div4
+              description: "Divide by 4"
+              value: 3
+            - name: Div5
+              description: "Divide by 5"
+              value: 4
+            - name: Div6
+              description: "Divide by 6"
+              value: 5
+            - name: Div7
+              description: "Divide by 7"
+              value: 6
+            - name: Div8
+              description: "Divide by 8"
+              value: 7
+            - name: Div9
+              description: "Divide by 9"
+              value: 8
+            - name: Div10
+              description: "Divide by 10"
+              value: 9
+            - name: Div11
+              description: "Divide by 11"
+              value: 10
+            - name: Div12
+              description: "Divide by 12"
+              value: 11
+            - name: Div13
+              description: "Divide by 13"
+              value: 12
+            - name: Div14
+              description: "Divide by 14"
+              value: 13
+            - name: Div15
+              description: "Divide by 15"
+              value: 14
+            - name: Div16
+              description: "Divide by 16"
+              value: 15
+
+        # CFGR.PDIV1, PDIV2: APB prescaler (pclk = hclk_lpsys / 2^PDIV)
+        enum/lpsys_rcc::vals::Pdiv:
+          bit_size: 3
+          variants:
+            - name: Div1
+              description: "Divide by 1"
+              value: 0
+            - name: Div2
+              description: "Divide by 2"
+              value: 1
+            - name: Div4
+              description: "Divide by 4"
+              value: 2
+            - name: Div8
+              description: "Divide by 8"
+              value: 3
+            - name: Div16
+              description: "Divide by 16"
+              value: 4
+            - name: Div32
+              description: "Divide by 32"
+              value: 5
+            - name: Div64
+              description: "Divide by 64"
+              value: 6
+            - name: Div128
+              description: "Divide by 128"
+              value: 7
+
+        # CFGR.MACDIV: MAC/RFC/PHY clock divider (clk_mac = hclk_lpsys / MACDIV)
+        # Note: This is a direct divisor value, not a power of 2
+        enum/lpsys_rcc::vals::Macdiv:
+          bit_size: 4
+          variants:
+            - name: Div1
+              description: "Divide by 1"
+              value: 1
+            - name: Div2
+              description: "Divide by 2"
+              value: 2
+            - name: Div3
+              description: "Divide by 3"
+              value: 3
+            - name: Div4
+              description: "Divide by 4"
+              value: 4
+            - name: Div5
+              description: "Divide by 5"
+              value: 5
+            - name: Div6
+              description: "Divide by 6"
+              value: 6
+            - name: Div7
+              description: "Divide by 7"
+              value: 7
+            - name: Div8
+              description: "Divide by 8"
+              value: 8
+            - name: Div9
+              description: "Divide by 9"
+              value: 9
+            - name: Div10
+              description: "Divide by 10"
+              value: 10
+            - name: Div11
+              description: "Divide by 11"
+              value: 11
+            - name: Div12
+              description: "Divide by 12"
+              value: 12
+            - name: Div13
+              description: "Divide by 13"
+              value: 13
+            - name: Div14
+              description: "Divide by 14"
+              value: 14
+            - name: Div15
+              description: "Divide by 15"
+              value: 15
+
+        # CSR.SEL_SYS: System clock source
+        enum/lpsys_rcc::vals::Sysclk:
+          bit_size: 1
+          variants:
+            - name: Hrc48
+              description: "48MHz internal RC oscillator"
+              value: 0
+            - name: Hxt48
+              description: "48MHz external crystal"
+              value: 1
+
+        # CSR.SEL_SYS_LP: Low-power mode sysclk override
+        enum/lpsys_rcc::vals::Lpsel:
+          bit_size: 1
+          variants:
+            - name: SelSys
+              description: "Use clock selected by SEL_SYS"
+              value: 0
+            - name: Wdt
+              description: "Use WDT clock (low power)"
+              value: 1
+
+        # CSR.SEL_TICK: SysTick reference clock source
+        enum/lpsys_rcc::vals::Ticksel:
+          bit_size: 2
+          variants:
+            - name: ClkRtc
+              description: "Use RTC clock"
+              value: 0
+            - name: Hrc48
+              description: "Use HRC48"
+              value: 2
+            - name: Hxt48
+              description: "Use HXT48"
+              value: 3
+
+        # CSR.SEL_PERI: Peripheral clock source
+        enum/lpsys_rcc::vals::Perisel:
+          bit_size: 1
+          variants:
+            - name: Hrc48
+              description: "Use HRC48 for peripheral clock"
+              value: 0
+            - name: Hxt48
+              description: "Use HXT48 for peripheral clock"
+              value: 1
+
+  # Apply enums to LPSYS_RCC registers
+  - !ModifyFieldsEnum
+      fieldset: lpsys_rcc::regs::Cfgr
+      field: hdiv1
+      enum: lpsys_rcc::vals::Hdiv
+
+  - !ModifyFieldsEnum
+      fieldset: lpsys_rcc::regs::Cfgr
+      field: pdiv1
+      enum: lpsys_rcc::vals::Pdiv
+
+  - !ModifyFieldsEnum
+      fieldset: lpsys_rcc::regs::Cfgr
+      field: pdiv2
+      enum: lpsys_rcc::vals::Pdiv
+
+  - !ModifyFieldsEnum
+      fieldset: lpsys_rcc::regs::Cfgr
+      field: macdiv
+      enum: lpsys_rcc::vals::Macdiv
+
+  - !ModifyFieldsEnum
+      fieldset: lpsys_rcc::regs::Csr
+      field: sel_sys
+      enum: lpsys_rcc::vals::Sysclk
+
+  - !ModifyFieldsEnum
+      fieldset: lpsys_rcc::regs::Csr
+      field: sel_sys_lp
+      enum: lpsys_rcc::vals::Lpsel
+
+  - !ModifyFieldsEnum
+      fieldset: lpsys_rcc::regs::Csr
+      field: sel_tick
+      enum: lpsys_rcc::vals::Ticksel
+
+  - !ModifyFieldsEnum
+      fieldset: lpsys_rcc::regs::Csr
+      field: sel_peri
+      enum: lpsys_rcc::vals::Perisel

--- a/transform/common/rcc.yaml
+++ b/transform/common/rcc.yaml
@@ -1,4 +1,5 @@
 transforms:
+  # --- HPSYS RCC ---
   - !MergeFieldsets
       from: hpsys_rcc::regs::Dll\d+cr
       to: hpsys_rcc::regs::Dllcr
@@ -9,68 +10,265 @@ transforms:
 
   - !Add
       ir:
-        #--- CSR ---
-        enum/hpsys_rcc::vals::SelUsbc:
+        # HPSYS_RCC enums
+
+        # CFGR.PDIV1, CFGR.PDIV2: APB prescaler (pclk = hclk / 2^PDIV)
+        enum/hpsys_rcc::vals::Pdiv:
+          bit_size: 3
+          variants:
+            - name: Div1
+              description: "Divide by 1"
+              value: 0
+            - name: Div2
+              description: "Divide by 2"
+              value: 1
+            - name: Div4
+              description: "Divide by 4"
+              value: 2
+            - name: Div8
+              description: "Divide by 8"
+              value: 3
+            - name: Div16
+              description: "Divide by 16"
+              value: 4
+            - name: Div32
+              description: "Divide by 32"
+              value: 5
+            - name: Div64
+              description: "Divide by 64"
+              value: 6
+            - name: Div128
+              description: "Divide by 128"
+              value: 7
+
+        # CSR.SEL_SYS, DWCFGR.SEL_SYS: System clock source
+        enum/hpsys_rcc::vals::Sysclk:
+          bit_size: 2
+          variants:
+            - name: Hrc48
+              description: "48MHz internal RC oscillator"
+              value: 0
+            - name: Hxt48
+              description: "48MHz external crystal"
+              value: 1
+            - name: Dbl96
+              description: "96MHz doubler (not implemented)"
+              value: 2
+            - name: Dll1
+              description: "DLL1 output"
+              value: 3
+
+        # DLLCR.STG: DLL multiplication stage (freq = 24MHz * (stg + 1))
+        enum/hpsys_rcc::vals::Dllstg:
+          bit_size: 4
+          variants:
+            - name: Mul1
+              description: "Multiply by 1 (24 MHz)"
+              value: 0
+            - name: Mul2
+              description: "Multiply by 2 (48 MHz)"
+              value: 1
+            - name: Mul3
+              description: "Multiply by 3 (72 MHz)"
+              value: 2
+            - name: Mul4
+              description: "Multiply by 4 (96 MHz)"
+              value: 3
+            - name: Mul5
+              description: "Multiply by 5 (120 MHz)"
+              value: 4
+            - name: Mul6
+              description: "Multiply by 6 (144 MHz)"
+              value: 5
+            - name: Mul7
+              description: "Multiply by 7 (168 MHz)"
+              value: 6
+            - name: Mul8
+              description: "Multiply by 8 (192 MHz)"
+              value: 7
+            - name: Mul9
+              description: "Multiply by 9 (216 MHz)"
+              value: 8
+            - name: Mul10
+              description: "Multiply by 10 (240 MHz)"
+              value: 9
+            - name: Mul11
+              description: "Multiply by 11 (264 MHz)"
+              value: 10
+            - name: Mul12
+              description: "Multiply by 12 (288 MHz)"
+              value: 11
+            - name: Mul13
+              description: "Multiply by 13 (312 MHz)"
+              value: 12
+            - name: Mul14
+              description: "Multiply by 14 (336 MHz)"
+              value: 13
+            - name: Mul15
+              description: "Multiply by 15 (360 MHz)"
+              value: 14
+            - name: Mul16
+              description: "Multiply by 16 (384 MHz)"
+              value: 15
+
+        # CSR.SEL_SYS_LP, DWCFGR.SEL_SYS_LP: Low-power mode sysclk override
+        enum/hpsys_rcc::vals::mux::Lpsel:
           bit_size: 1
           variants:
-            - name: ClkSys
+            - name: SelSys
+              description: "Use clock selected by SEL_SYS"
+              value: 0
+            - name: Wdt
+              description: "Use WDT clock (low power)"
+              value: 1
+
+        # CSR.SEL_USBC: USB clock source
+        enum/hpsys_rcc::vals::mux::Usbsel:
+          bit_size: 1
+          variants:
+            - name: Sysclk
+              description: "Use system clock"
               value: 0
             - name: Dll2
+              description: "Use DLL2 clock"
               value: 1
-        enum/hpsys_rcc::vals::SelTick:
+
+        # CSR.SEL_TICK: SysTick reference clock source
+        enum/hpsys_rcc::vals::mux::Ticksel:
           bit_size: 2
           variants:
             - name: ClkRtc
+              description: "Use RTC clock"
               value: 0
             - name: Hrc48
+              description: "Use HRC48"
               value: 2
             - name: Hxt48
+              description: "Use HXT48"
               value: 3
-        enum/hpsys_rcc::vals::SelPeri:
+
+        # CSR.SEL_PERI: Peripheral clock source
+        enum/hpsys_rcc::vals::mux::Perisel:
           bit_size: 1
           variants:
             - name: Hrc48
+              description: "Use HRC48 for peripheral clock"
               value: 0
             - name: Hxt48
+              description: "Use HXT48 for peripheral clock"
               value: 1
-        enum/hpsys_rcc::vals::SelSys:
+
+        # CSR.SEL_MPI1, CSR.SEL_MPI2: MPI (Flash/PSRAM) clock source
+        enum/hpsys_rcc::vals::mux::Mpisel:
           bit_size: 2
           variants:
-            - name: Hrc48
+            - name: Peri
+              description: "Use clk_peri_hpsys"
               value: 0
-            - name: Hxt48
-              value: 1
-            - name: Dbl96
-              value: 2
             - name: Dll1
-              value: 3
+              description: "Use DLL1 clock"
+              value: 1
+            - name: Dll2
+              description: "Use DLL2 clock"
+              value: 2
+
+        # PMUC.CR.SEL_LPCLK: WDT and FSM clock source
+        enum/hpsys_rcc::vals::mux::Wdtsel:
+          bit_size: 1
+          variants:
+            - name: Lrc10
+              description: "Use LRC10K (100 kHz)"
+              value: 0
+            - name: Lrc32
+              description: "Use LRC32K (32 kHz)"
+              value: 1
+
+        # RTC.CR.LPCKSEL: RTC and LPTIM clock source
+        enum/hpsys_rcc::vals::mux::Rtcsel:
+          bit_size: 1
+          variants:
+            - name: Lrc10
+              description: "Use LRC10K (100 kHz)"
+              value: 0
+            - name: Lxt32
+              description: "Use LXT32K (32.768 kHz)"
+              value: 1
+
+  # Apply enums to HPSYS_RCC registers
+  - !ModifyFieldsEnum
+      fieldset: hpsys_rcc::regs::Cfgr
+      field: pdiv1
+      enum: hpsys_rcc::vals::Pdiv
 
   - !ModifyFieldsEnum
-      fieldset: hpsys_rcc::regs::Csr
-      field: sel_usbc
-      enum: hpsys_rcc::vals::SelUsbc
-
-  - !ModifyFieldsEnum
-      fieldset: hpsys_rcc::regs::Csr
-      field: sel_tick
-      enum: hpsys_rcc::vals::SelTick
-
-  - !ModifyFieldsEnum
-      fieldset: hpsys_rcc::regs::Csr
-      field: sel_peri
-      enum: hpsys_rcc::vals::SelPeri
+      fieldset: hpsys_rcc::regs::Cfgr
+      field: pdiv2
+      enum: hpsys_rcc::vals::Pdiv
 
   - !ModifyFieldsEnum
       fieldset: hpsys_rcc::regs::Csr
       field: sel_sys
-      enum: hpsys_rcc::vals::SelSys
+      enum: hpsys_rcc::vals::Sysclk
 
-  # --- LPSYS RCC ---
+  - !ModifyFieldsEnum
+      fieldset: hpsys_rcc::regs::Csr
+      field: sel_peri
+      enum: hpsys_rcc::vals::mux::Perisel
 
-  # LPSYS RCC clock select enums
+  - !ModifyFieldsEnum
+      fieldset: hpsys_rcc::regs::Csr
+      field: sel_tick
+      enum: hpsys_rcc::vals::mux::Ticksel
+
+  - !ModifyFieldsEnum
+      fieldset: hpsys_rcc::regs::Csr
+      field: sel_usbc
+      enum: hpsys_rcc::vals::mux::Usbsel
+
+  - !ModifyFieldsEnum
+      fieldset: hpsys_rcc::regs::Csr
+      field: sel_mpi1
+      enum: hpsys_rcc::vals::mux::Mpisel
+
+  - !ModifyFieldsEnum
+      fieldset: hpsys_rcc::regs::Csr
+      field: sel_mpi2
+      enum: hpsys_rcc::vals::mux::Mpisel
+
+  - !ModifyFieldsEnum
+      fieldset: hpsys_rcc::regs::Csr
+      field: sel_sys_lp
+      enum: hpsys_rcc::vals::mux::Lpsel
+
+  - !ModifyFieldsEnum
+      fieldset: hpsys_rcc::regs::Dllcr
+      field: stg
+      enum: hpsys_rcc::vals::Dllstg
+
+  - !ModifyFieldsEnum
+      fieldset: hpsys_rcc::regs::Dwcfgr
+      field: sel_sys
+      enum: hpsys_rcc::vals::Sysclk
+
+  - !ModifyFieldsEnum
+      fieldset: hpsys_rcc::regs::Dwcfgr
+      field: sel_sys_lp
+      enum: hpsys_rcc::vals::mux::Lpsel
+
+  - !ModifyFieldsEnum
+      fieldset: hpsys_rcc::regs::Dwcfgr
+      field: pdiv1
+      enum: hpsys_rcc::vals::Pdiv
+
+  - !ModifyFieldsEnum
+      fieldset: hpsys_rcc::regs::Dwcfgr
+      field: pdiv2
+      enum: hpsys_rcc::vals::Pdiv
+
+  # LPSYS_RCC enums
   - !Add
       ir:
-        # --- CSR ---
+        # CSR.SEL_SYS: System clock source
         enum/lpsys_rcc::vals::SelSys:
           bit_size: 1
           variants:
@@ -78,6 +276,8 @@ transforms:
               value: 0
             - name: Hxt48
               value: 1
+
+        # CSR.SEL_PERI: Peripheral clock source
         enum/lpsys_rcc::vals::SelPeri:
           bit_size: 1
           variants:
@@ -85,6 +285,8 @@ transforms:
               value: 0
             - name: Hxt48
               value: 1
+
+        # CSR.SEL_TICK: SysTick reference clock source
         enum/lpsys_rcc::vals::SelTick:
           bit_size: 2
           variants:
@@ -95,6 +297,7 @@ transforms:
             - name: Hxt48
               value: 3
 
+  # Apply enums to LPSYS_RCC registers
   - !ModifyFieldsEnum
       fieldset: lpsys_rcc::regs::Csr
       field: sel_sys
@@ -109,3 +312,15 @@ transforms:
       fieldset: lpsys_rcc::regs::Csr
       field: sel_tick
       enum: lpsys_rcc::vals::SelTick
+
+  # Apply enums to PMUC registers
+  - !ModifyFieldsEnum
+      fieldset: pmuc::regs::Cr
+      field: sel_lpclk
+      enum: hpsys_rcc::vals::mux::Wdtsel
+
+  # Apply enums to RTC registers 
+  - !ModifyFieldsEnum
+      fieldset: rtc::regs::Cr
+      field: lpcksel
+      enum: hpsys_rcc::vals::mux::Rtcsel

--- a/transform/common/rcc.yaml
+++ b/transform/common/rcc.yaml
@@ -426,7 +426,7 @@ transforms:
               value: 1
 
         # CSR.SEL_SYS_LP: Low-power mode sysclk override
-        enum/lpsys_rcc::vals::Lpsel:
+        enum/lpsys_rcc::vals::mux::Lpsel:
           bit_size: 1
           variants:
             - name: SelSys
@@ -437,7 +437,7 @@ transforms:
               value: 1
 
         # CSR.SEL_TICK: SysTick reference clock source
-        enum/lpsys_rcc::vals::Ticksel:
+        enum/lpsys_rcc::vals::mux::Ticksel:
           bit_size: 2
           variants:
             - name: ClkRtc
@@ -451,7 +451,7 @@ transforms:
               value: 3
 
         # CSR.SEL_PERI: Peripheral clock source
-        enum/lpsys_rcc::vals::Perisel:
+        enum/lpsys_rcc::vals::mux::Perisel:
           bit_size: 1
           variants:
             - name: Hrc48
@@ -490,14 +490,14 @@ transforms:
   - !ModifyFieldsEnum
       fieldset: lpsys_rcc::regs::Csr
       field: sel_sys_lp
-      enum: lpsys_rcc::vals::Lpsel
+      enum: lpsys_rcc::vals::mux::Lpsel
 
   - !ModifyFieldsEnum
       fieldset: lpsys_rcc::regs::Csr
       field: sel_tick
-      enum: lpsys_rcc::vals::Ticksel
+      enum: lpsys_rcc::vals::mux::Ticksel
 
   - !ModifyFieldsEnum
       fieldset: lpsys_rcc::regs::Csr
       field: sel_peri
-      enum: lpsys_rcc::vals::Perisel
+      enum: lpsys_rcc::vals::mux::Perisel


### PR DESCRIPTION
基于 OpenSiFli/sifli-rs#25 的时钟树重构，避免在hal中定义大量mux枚举。