### PR TITLE
feat(lpsys): add BT peripherals (BT_RFC/BT_PHY/BT_MAC)

### DIFF
--- a/transform/SF32LB52x.yaml
+++ b/transform/SF32LB52x.yaml
@@ -10,6 +10,10 @@ includes:
   - common/mailbox.yaml
   - common/patch.yaml
   - common/lcdc.yaml
+  # Bluetooth peripherals (LPSYS, not in SVD)
+  - common/bt_rfc.yaml
+  - common/bt_phy.yaml
+  - common/bt_mac.yaml
 
 transforms:
   # ------------------------------ LPSYS ------------------------------
@@ -27,7 +31,7 @@ transforms:
   # LPSYS peripherals, reserved for lpsys firmware
   - !DeletePeripherals
       devices: .*
-      from: (LPTIM3|BTIM[34]|CRC2|PTC2|WDT2|USART[45]|DMAC2)
+      from: (LPTIM3|BTIM[34]|CRC2|PTC2|WDT2|USART[45])
 
   # ------------------------------ PINMUX ------------------------------
   # PINMUX pad_pa[39, 42] is different with pad_pa[0, 38], [43, 44]

--- a/transform/common/bt_mac.yaml
+++ b/transform/common/bt_mac.yaml
@@ -1,0 +1,3433 @@
+transforms:
+
+  - !AddPeripherals
+      devices: .*
+      peripherals:
+        - name: BT_MAC
+          base_address: 0x40090000
+          block: bt_mac::BtMac
+
+  - !Add
+      ir:
+        block/bt_mac::BtMac:
+          items:
+            - name: rwdmcntl
+              byte_offset: 0x0
+              fieldset: bt_mac::regs::Rwdmcntl
+            - name: dmversion
+              byte_offset: 0x4
+              fieldset: bt_mac::regs::Dmversion
+            - name: dmintcntl0
+              byte_offset: 0xc
+              fieldset: bt_mac::regs::Dmintcntl0
+            - name: dmintstat0
+              byte_offset: 0x10
+              fieldset: bt_mac::regs::Dmintstat0
+            - name: dmintack0
+              byte_offset: 0x14
+              fieldset: bt_mac::regs::Dmintack0
+            - name: dmintcntl1
+              byte_offset: 0x18
+              fieldset: bt_mac::regs::Dmintcntl1
+            - name: dmintstat1
+              byte_offset: 0x1c
+              fieldset: bt_mac::regs::Dmintstat1
+            - name: dmintack1
+              byte_offset: 0x20
+              fieldset: bt_mac::regs::Dmintack1
+            - name: actfifostat
+              byte_offset: 0x24
+              fieldset: bt_mac::regs::Actfifostat
+            - name: etptr
+              byte_offset: 0x2c
+              fieldset: bt_mac::regs::Etptr
+            - name: deepslcntl
+              byte_offset: 0x30
+              fieldset: bt_mac::regs::Deepslcntl
+            - name: finecntcorr
+              byte_offset: 0x40
+              fieldset: bt_mac::regs::Finecntcorr
+            - name: clkncntcorr
+              byte_offset: 0x44
+              fieldset: bt_mac::regs::Clkncntcorr
+            - name: dmdiagcntl
+              byte_offset: 0x50
+              fieldset: bt_mac::regs::Dmdiagcntl
+            - name: dmdiagstat
+              byte_offset: 0x54
+              fieldset: bt_mac::regs::Dmdiagstat
+            - name: dmdebugaddmax
+              byte_offset: 0x58
+              fieldset: bt_mac::regs::Dmdebugaddmax
+            - name: dmdebugaddmin
+              byte_offset: 0x5c
+              fieldset: bt_mac::regs::Dmdebugaddmin
+            - name: dmerrortypestat
+              byte_offset: 0x60
+              fieldset: bt_mac::regs::Dmerrortypestat
+            - name: dmswprofiling
+              byte_offset: 0x64
+              fieldset: bt_mac::regs::Dmswprofiling
+            - name: dmradiocntl0
+              byte_offset: 0x70
+              fieldset: bt_mac::regs::Dmradiocntl0
+            - name: dmradiocntl1
+              byte_offset: 0x74
+              fieldset: bt_mac::regs::Dmradiocntl1
+            - name: dmradiocntl2
+              byte_offset: 0x78
+              fieldset: bt_mac::regs::Dmradiocntl2
+            - name: dmradiocntl3
+              byte_offset: 0x7c
+              fieldset: bt_mac::regs::Dmradiocntl3
+            - name: dmradiocntl4
+              byte_offset: 0x80
+              fieldset: bt_mac::regs::Dmradiocntl4
+            - name: aescntl
+              byte_offset: 0xb0
+              fieldset: bt_mac::regs::Aescntl
+            - name: aeskey31_0
+              byte_offset: 0xb4
+              fieldset: bt_mac::regs::Aeskey310
+            - name: aeskey63_32
+              byte_offset: 0xb8
+              fieldset: bt_mac::regs::Aeskey6332
+            - name: aeskey95_64
+              byte_offset: 0xbc
+              fieldset: bt_mac::regs::Aeskey9564
+            - name: aeskey127_96
+              byte_offset: 0xc0
+              fieldset: bt_mac::regs::Aeskey12796
+            - name: dmaesptr
+              byte_offset: 0xc4
+              fieldset: bt_mac::regs::Dmaesptr
+            - name: txmicval
+              byte_offset: 0xc8
+              fieldset: bt_mac::regs::Txmicval
+            - name: rxmicval
+              byte_offset: 0xcc
+              fieldset: bt_mac::regs::Rxmicval
+            - name: prioscharb
+              byte_offset: 0xd0
+              fieldset: bt_mac::regs::Prioscharb
+            - name: dmtimgencntl
+              byte_offset: 0xe0
+              fieldset: bt_mac::regs::Dmtimgencntl
+            - name: finetimtgt
+              byte_offset: 0xe4
+              fieldset: bt_mac::regs::Finetimtgt
+            - name: clkntgt1
+              byte_offset: 0xe8
+              fieldset: bt_mac::regs::Clkntgt1
+            - name: hmicrosectgt1
+              byte_offset: 0xec
+              fieldset: bt_mac::regs::Hmicrosectgt1
+            - name: clkntgt2
+              byte_offset: 0xf0
+              fieldset: bt_mac::regs::Clkntgt2
+            - name: hmicrosectgt2
+              byte_offset: 0xf4
+              fieldset: bt_mac::regs::Hmicrosectgt2
+            - name: clkntgt3
+              byte_offset: 0xf8
+              fieldset: bt_mac::regs::Clkntgt3
+            - name: hmicrosectgt3
+              byte_offset: 0xfc
+              fieldset: bt_mac::regs::Hmicrosectgt3
+            - name: slotclk
+              byte_offset: 0x100
+              fieldset: bt_mac::regs::Slotclk
+            - name: finetimecnt
+              byte_offset: 0x104
+              fieldset: bt_mac::regs::Finetimecnt
+            - name: actschcntl
+              byte_offset: 0x110
+              fieldset: bt_mac::regs::Actschcntl
+            - name: rccal_ctrl
+              byte_offset: 0x114
+              fieldset: bt_mac::regs::RccalCtrl
+            - name: rccal_result
+              byte_offset: 0x118
+              fieldset: bt_mac::regs::RccalResult
+            - name: dfancntl
+              byte_offset: 0x194
+              fieldset: bt_mac::regs::Dfancntl
+            - name: rwbtcntl
+              byte_offset: 0x400
+              fieldset: bt_mac::regs::Rwbtcntl
+            - name: btversion
+              byte_offset: 0x404
+              fieldset: bt_mac::regs::Btversion
+            - name: btintcntl0
+              byte_offset: 0x40c
+              fieldset: bt_mac::regs::Btintcntl0
+            - name: btintstat0
+              byte_offset: 0x410
+              fieldset: bt_mac::regs::Btintstat0
+            - name: btintack0
+              byte_offset: 0x414
+              fieldset: bt_mac::regs::Btintack0
+            - name: btcurrentrxdescptr
+              byte_offset: 0x428
+              fieldset: bt_mac::regs::Btcurrentrxdescptr
+            - name: btdiagcntl
+              byte_offset: 0x450
+              fieldset: bt_mac::regs::Btdiagcntl
+            - name: btdiagstat
+              byte_offset: 0x454
+              fieldset: bt_mac::regs::Btdiagstat
+            - name: btdebugaddmax
+              byte_offset: 0x458
+              fieldset: bt_mac::regs::Btdebugaddmax
+            - name: btdebugaddmin
+              byte_offset: 0x45c
+              fieldset: bt_mac::regs::Btdebugaddmin
+            - name: bterrortypestat
+              byte_offset: 0x460
+              fieldset: bt_mac::regs::Bterrortypestat
+            - name: btswprofiling
+              byte_offset: 0x464
+              fieldset: bt_mac::regs::Btswprofiling
+            - name: btradiocntl2
+              byte_offset: 0x478
+              fieldset: bt_mac::regs::Btradiocntl2
+            - name: btradiocntl3
+              byte_offset: 0x47c
+              fieldset: bt_mac::regs::Btradiocntl3
+            - name: btradiopwrupdn
+              byte_offset: 0x48c
+              fieldset: bt_mac::regs::Btradiopwrupdn
+            - name: btradiotxrxtim
+              byte_offset: 0x490
+              fieldset: bt_mac::regs::Btradiotxrxtim
+            - name: btrftestcntl
+              byte_offset: 0x4d0
+              fieldset: bt_mac::regs::Btrftestcntl
+            - name: btrftestfreq
+              byte_offset: 0x4d4
+              fieldset: bt_mac::regs::Btrftestfreq
+            - name: btrftesttxstat
+              byte_offset: 0x4d8
+              fieldset: bt_mac::regs::Btrftesttxstat
+            - name: btrftestrxstat
+              byte_offset: 0x4dc
+              fieldset: bt_mac::regs::Btrftestrxstat
+            - name: startfrmclknts
+              byte_offset: 0x514
+              fieldset: bt_mac::regs::Startfrmclknts
+            - name: startfrmfinecntts
+              byte_offset: 0x518
+              fieldset: bt_mac::regs::Startfrmfinecntts
+            - name: endfrmclknts
+              byte_offset: 0x51c
+              fieldset: bt_mac::regs::Endfrmclknts
+            - name: endfrmfinecntts
+              byte_offset: 0x520
+              fieldset: bt_mac::regs::Endfrmfinecntts
+            - name: skipfrmclknts
+              byte_offset: 0x524
+              fieldset: bt_mac::regs::Skipfrmclknts
+            - name: skipfrmfinecntts
+              byte_offset: 0x528
+              fieldset: bt_mac::regs::Skipfrmfinecntts
+            - name: abtraincntl
+              byte_offset: 0x530
+              fieldset: bt_mac::regs::Abtraincntl
+            - name: edrcntl
+              byte_offset: 0x534
+              fieldset: bt_mac::regs::Edrcntl
+            - name: pcacntl0
+              byte_offset: 0x540
+              fieldset: bt_mac::regs::Pcacntl0
+            - name: pcacntl1
+              byte_offset: 0x544
+              fieldset: bt_mac::regs::Pcacntl1
+            - name: pcastat
+              byte_offset: 0x548
+              fieldset: bt_mac::regs::Pcastat
+            - name: btcoexifcntl0
+              byte_offset: 0x550
+              fieldset: bt_mac::regs::Btcoexifcntl0
+            - name: btcoexifcntl1
+              byte_offset: 0x554
+              fieldset: bt_mac::regs::Btcoexifcntl1
+            - name: btcoexifcntl2
+              byte_offset: 0x558
+              fieldset: bt_mac::regs::Btcoexifcntl2
+            - name: btmprio0
+              byte_offset: 0x560
+              fieldset: bt_mac::regs::Btmprio0
+            - name: btmprio1
+              byte_offset: 0x564
+              fieldset: bt_mac::regs::Btmprio1
+            - name: btmprio2
+              byte_offset: 0x568
+              fieldset: bt_mac::regs::Btmprio2
+            - name: coexchn0
+              byte_offset: 0x570
+              fieldset: bt_mac::regs::Coexchn0
+            - name: coexchn1
+              byte_offset: 0x574
+              fieldset: bt_mac::regs::Coexchn1
+            - name: coexchn2
+              byte_offset: 0x578
+              fieldset: bt_mac::regs::Coexchn2
+            - name: escochancntl0
+              byte_offset: 0x610
+              fieldset: bt_mac::regs::Escochancntl0
+            - name: escomutecntl0
+              byte_offset: 0x614
+              fieldset: bt_mac::regs::Escomutecntl0
+            - name: escocurrenttxptr0
+              byte_offset: 0x618
+              fieldset: bt_mac::regs::Escocurrenttxptr0
+            - name: escocurrentrxptr0
+              byte_offset: 0x61c
+              fieldset: bt_mac::regs::Escocurrentrxptr0
+            - name: escoltcntl0
+              byte_offset: 0x620
+              fieldset: bt_mac::regs::Escoltcntl0
+            - name: escotrcntl0
+              byte_offset: 0x624
+              fieldset: bt_mac::regs::Escotrcntl0
+            - name: escodaycnt0
+              byte_offset: 0x628
+              fieldset: bt_mac::regs::Escodaycnt0
+            - name: escochancntl1
+              byte_offset: 0x630
+              fieldset: bt_mac::regs::Escochancntl1
+            - name: escomutecntl1
+              byte_offset: 0x634
+              fieldset: bt_mac::regs::Escomutecntl1
+            - name: escocurrenttxptr1
+              byte_offset: 0x638
+              fieldset: bt_mac::regs::Escocurrenttxptr1
+            - name: escocurrentrxptr1
+              byte_offset: 0x63c
+              fieldset: bt_mac::regs::Escocurrentrxptr1
+            - name: escoltcntl1
+              byte_offset: 0x640
+              fieldset: bt_mac::regs::Escoltcntl1
+            - name: escotrcntl1
+              byte_offset: 0x644
+              fieldset: bt_mac::regs::Escotrcntl1
+            - name: escodaycnt1
+              byte_offset: 0x648
+              fieldset: bt_mac::regs::Escodaycnt1
+            - name: escochancntl2
+              byte_offset: 0x650
+              fieldset: bt_mac::regs::Escochancntl2
+            - name: escomutecntl2
+              byte_offset: 0x654
+              fieldset: bt_mac::regs::Escomutecntl2
+            - name: escocurrenttxptr2
+              byte_offset: 0x658
+              fieldset: bt_mac::regs::Escocurrenttxptr2
+            - name: escocurrentrxptr2
+              byte_offset: 0x65c
+              fieldset: bt_mac::regs::Escocurrentrxptr2
+            - name: escoltcntl2
+              byte_offset: 0x660
+              fieldset: bt_mac::regs::Escoltcntl2
+            - name: escotrcntl2
+              byte_offset: 0x664
+              fieldset: bt_mac::regs::Escotrcntl2
+            - name: escodaycnt2
+              byte_offset: 0x668
+              fieldset: bt_mac::regs::Escodaycnt2
+            - name: audiocntl0
+              byte_offset: 0x670
+              fieldset: bt_mac::regs::Audiocntl0
+            - name: audiocntl1
+              byte_offset: 0x674
+              fieldset: bt_mac::regs::Audiocntl1
+            - name: audiocntl2
+              byte_offset: 0x678
+              fieldset: bt_mac::regs::Audiocntl2
+            - name: rwblecntl
+              byte_offset: 0x800
+              fieldset: bt_mac::regs::Rwblecntl
+            - name: bleversion
+              byte_offset: 0x804
+              fieldset: bt_mac::regs::Bleversion
+            - name: bleintcntl0
+              byte_offset: 0x80c
+              fieldset: bt_mac::regs::Bleintcntl0
+            - name: bleintstat0
+              byte_offset: 0x810
+              fieldset: bt_mac::regs::Bleintstat0
+            - name: bleintack0
+              byte_offset: 0x814
+              fieldset: bt_mac::regs::Bleintack0
+            - name: blecurrentrxdescptr
+              byte_offset: 0x828
+              fieldset: bt_mac::regs::Blecurrentrxdescptr
+            - name: blediagcntl
+              byte_offset: 0x850
+              fieldset: bt_mac::regs::Blediagcntl
+            - name: blediagstat
+              byte_offset: 0x854
+              fieldset: bt_mac::regs::Blediagstat
+            - name: bledebugaddmax
+              byte_offset: 0x858
+              fieldset: bt_mac::regs::Bledebugaddmax
+            - name: bledebugaddmin
+              byte_offset: 0x85c
+              fieldset: bt_mac::regs::Bledebugaddmin
+            - name: bleerrortypestat
+              byte_offset: 0x860
+              fieldset: bt_mac::regs::Bleerrortypestat
+            - name: bleswprofiling
+              byte_offset: 0x864
+              fieldset: bt_mac::regs::Bleswprofiling
+            - name: bleradiocntl2
+              byte_offset: 0x878
+              fieldset: bt_mac::regs::Bleradiocntl2
+            - name: bleradiocntl3
+              byte_offset: 0x87c
+              fieldset: bt_mac::regs::Bleradiocntl3
+            - name: bleradiopwrupdn0
+              byte_offset: 0x880
+              fieldset: bt_mac::regs::Bleradiopwrupdn0
+            - name: bleradiopwrupdn1
+              byte_offset: 0x884
+              fieldset: bt_mac::regs::Bleradiopwrupdn1
+            - name: bleradiopwrupdn2
+              byte_offset: 0x888
+              fieldset: bt_mac::regs::Bleradiopwrupdn2
+            - name: bleradiopwrupdn3
+              byte_offset: 0x88c
+              fieldset: bt_mac::regs::Bleradiopwrupdn3
+            - name: bleradiotxrxtim0
+              byte_offset: 0x890
+              fieldset: bt_mac::regs::Bleradiotxrxtim0
+            - name: bleradiotxrxtim1
+              byte_offset: 0x894
+              fieldset: bt_mac::regs::Bleradiotxrxtim1
+            - name: bleradiotxrxtim2
+              byte_offset: 0x898
+              fieldset: bt_mac::regs::Bleradiotxrxtim2
+            - name: bleradiotxrxtim3
+              byte_offset: 0x89c
+              fieldset: bt_mac::regs::Bleradiotxrxtim3
+            - name: blerftestcntl
+              byte_offset: 0x8d0
+              fieldset: bt_mac::regs::Blerftestcntl
+            - name: blerftesttxstat
+              byte_offset: 0x8d4
+              fieldset: bt_mac::regs::Blerftesttxstat
+            - name: blerftestrxstat
+              byte_offset: 0x8d8
+              fieldset: bt_mac::regs::Blerftestrxstat
+            - name: startevtclkn
+              byte_offset: 0x914
+              fieldset: bt_mac::regs::Startevtclkn
+            - name: startevtfinecnt
+              byte_offset: 0x918
+              fieldset: bt_mac::regs::Startevtfinecnt
+            - name: endevtclkn
+              byte_offset: 0x91c
+              fieldset: bt_mac::regs::Endevtclkn
+            - name: endevtfinecnt
+              byte_offset: 0x920
+              fieldset: bt_mac::regs::Endevtfinecnt
+            - name: skipevtclkn
+              byte_offset: 0x924
+              fieldset: bt_mac::regs::Skipevtclkn
+            - name: skipevtfinecnt
+              byte_offset: 0x928
+              fieldset: bt_mac::regs::Skipevtfinecnt
+            - name: advtim
+              byte_offset: 0x930
+              fieldset: bt_mac::regs::Advtim
+            - name: actscancntl
+              byte_offset: 0x934
+              fieldset: bt_mac::regs::Actscancntl
+            - name: wpalcntl
+              byte_offset: 0x940
+              fieldset: bt_mac::regs::Wpalcntl
+            - name: wpalcurrent
+              byte_offset: 0x944
+              fieldset: bt_mac::regs::Wpalcurrent
+            - name: search_timeout
+              byte_offset: 0x948
+              fieldset: bt_mac::regs::SearchTimeout
+            - name: blecoexifcntl0
+              byte_offset: 0x950
+              fieldset: bt_mac::regs::Blecoexifcntl0
+            - name: blecoexifcntl1
+              byte_offset: 0x954
+              fieldset: bt_mac::regs::Blecoexifcntl1
+            - name: blecoexifcntl2
+              byte_offset: 0x958
+              fieldset: bt_mac::regs::Blecoexifcntl2
+            - name: blemprio0
+              byte_offset: 0x960
+              fieldset: bt_mac::regs::Blemprio0
+            - name: blemprio1
+              byte_offset: 0x964
+              fieldset: bt_mac::regs::Blemprio1
+            - name: blemprio2
+              byte_offset: 0x968
+              fieldset: bt_mac::regs::Blemprio2
+            - name: ralcntl
+              byte_offset: 0x970
+              fieldset: bt_mac::regs::Ralcntl
+            - name: ralcurrent
+              byte_offset: 0x974
+              fieldset: bt_mac::regs::Ralcurrent
+            - name: ral_local_rnd
+              byte_offset: 0x978
+              fieldset: bt_mac::regs::RalLocalRnd
+            - name: ral_peer_rnd
+              byte_offset: 0x97c
+              fieldset: bt_mac::regs::RalPeerRnd
+            - name: dfcntl0_1us
+              byte_offset: 0x980
+              fieldset: bt_mac::regs::Dfcntl01us
+            - name: dfcntl0_2us
+              byte_offset: 0x984
+              fieldset: bt_mac::regs::Dfcntl02us
+            - name: dfcntl1_1us
+              byte_offset: 0x988
+              fieldset: bt_mac::regs::Dfcntl11us
+            - name: dfcntl1_2us
+              byte_offset: 0x98c
+              fieldset: bt_mac::regs::Dfcntl12us
+            - name: dfcurrentptr
+              byte_offset: 0x990
+              fieldset: bt_mac::regs::Dfcurrentptr
+            - name: dfantcntl
+              byte_offset: 0x994
+              fieldset: bt_mac::regs::Dfantcntl
+            - name: dfifcntl
+              byte_offset: 0x998
+              fieldset: bt_mac::regs::Dfifcntl
+            - name: freqselcntl
+              byte_offset: 0x9a0
+              fieldset: bt_mac::regs::Freqselcntl
+            - name: freqselptr
+              byte_offset: 0x9a4
+              fieldset: bt_mac::regs::Freqselptr
+            - name: freqsel_cs1_seed
+              byte_offset: 0x9a8
+              fieldset: bt_mac::regs::FreqselCs1Seed
+            - name: freq_cs2_seed
+              byte_offset: 0x9ac
+              fieldset: bt_mac::regs::FreqCs2Seed
+            - name: freqsel_llchmap0
+              byte_offset: 0x9b0
+              fieldset: bt_mac::regs::FreqselLlchmap0
+            - name: freqsel_llchmap1
+              byte_offset: 0x9b4
+              fieldset: bt_mac::regs::FreqselLlchmap1
+            - name: isocntcntl
+              byte_offset: 0x9c0
+              fieldset: bt_mac::regs::Isocntcntl
+            - name: isocntsamp
+              byte_offset: 0x9c4
+              fieldset: bt_mac::regs::Isocntsamp
+            - name: isocntcorr
+              byte_offset: 0x9c8
+              fieldset: bt_mac::regs::Isocntcorr
+            - name: isointcorr_hus
+              byte_offset: 0x9cc
+              fieldset: bt_mac::regs::IsointcorrHus
+            - name: isointcntl
+              byte_offset: 0x9d0
+              fieldset: bt_mac::regs::Isointcntl
+            - name: isointstat
+              byte_offset: 0x9d4
+              fieldset: bt_mac::regs::Isointstat
+            - name: isointack
+              byte_offset: 0x9d8
+              fieldset: bt_mac::regs::Isointack
+            - name: isogpiocntl
+              byte_offset: 0x9e0
+              fieldset: bt_mac::regs::Isogpiocntl
+            - name: isotimertgt0
+              byte_offset: 0x9f0
+              fieldset: bt_mac::regs::Isotimertgt0
+            - name: isotimertgt1
+              byte_offset: 0x9f4
+              fieldset: bt_mac::regs::Isotimertgt1
+            - name: isotimertgt2
+              byte_offset: 0x9f8
+              fieldset: bt_mac::regs::Isotimertgt2
+            - name: isotimertgt3
+              byte_offset: 0x9fc
+              fieldset: bt_mac::regs::Isotimertgt3
+            - name: isotimertgt4
+              byte_offset: 0xa00
+              fieldset: bt_mac::regs::Isotimertgt4
+            - name: isotimertgt5
+              byte_offset: 0xa04
+              fieldset: bt_mac::regs::Isotimertgt5
+            - name: isotimertgt6
+              byte_offset: 0xa08
+              fieldset: bt_mac::regs::Isotimertgt6
+            - name: isotimertgt7
+              byte_offset: 0xa0c
+              fieldset: bt_mac::regs::Isotimertgt7
+
+        fieldset/bt_mac::regs::Rwdmcntl:
+          description: "RWDMCNTL"
+          fields:
+            - name: swint_req
+              bit_offset: 27
+              bit_size: 1
+            - name: radiocntl_soft_rst
+              bit_offset: 28
+              bit_size: 1
+            - name: master_tgsoft_rst
+              bit_offset: 30
+              bit_size: 1
+            - name: master_soft_rst
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Dmversion:
+          description: "DMVERSION"
+          fields:
+            - name: build_num
+              bit_offset: 0
+              bit_size: 8
+            - name: upg
+              bit_offset: 8
+              bit_size: 8
+            - name: rel
+              bit_offset: 16
+              bit_size: 8
+            - name: typ
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Dmintcntl0:
+          description: "DMINTCNTL0"
+          fields:
+            - name: errorintmsk
+              bit_offset: 16
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Dmintstat0:
+          description: "DMINTSTAT0"
+          fields:
+            - name: errorintstat
+              bit_offset: 16
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Dmintack0:
+          description: "DMINTACK0"
+          fields:
+            - name: errorintack
+              bit_offset: 16
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Dmintcntl1:
+          description: "DMINTCNTL1"
+          fields:
+            - name: clknintmsk
+              bit_offset: 0
+              bit_size: 1
+            - name: slpintmsk
+              bit_offset: 1
+              bit_size: 1
+            - name: cryptintmsk
+              bit_offset: 2
+              bit_size: 1
+            - name: swintmsk
+              bit_offset: 3
+              bit_size: 1
+            - name: finetgtntmsk
+              bit_offset: 4
+              bit_size: 1
+            - name: timestamptgt1intmsk
+              bit_offset: 5
+              bit_size: 1
+            - name: timestamptgt2intmsk
+              bit_offset: 6
+              bit_size: 1
+            - name: timestamptgt3intmsk
+              bit_offset: 7
+              bit_size: 1
+            - name: rccalintmsk
+              bit_offset: 8
+              bit_size: 1
+            - name: fifointmsk
+              bit_offset: 15
+              bit_size: 1
+            - name: clknintsrval
+              bit_offset: 24
+              bit_size: 4
+            - name: clknintsrmsk
+              bit_offset: 28
+              bit_size: 3
+
+        fieldset/bt_mac::regs::Dmintstat1:
+          description: "DMINTSTAT1"
+          fields:
+            - name: clknintstat
+              bit_offset: 0
+              bit_size: 1
+            - name: slpintstat
+              bit_offset: 1
+              bit_size: 1
+            - name: cryptintstat
+              bit_offset: 2
+              bit_size: 1
+            - name: swintstat
+              bit_offset: 3
+              bit_size: 1
+            - name: finetgtintstat
+              bit_offset: 4
+              bit_size: 1
+            - name: timestamptgt1intstat
+              bit_offset: 5
+              bit_size: 1
+            - name: timestamptgt2intstat
+              bit_offset: 6
+              bit_size: 1
+            - name: timestamptgt3intstat
+              bit_offset: 7
+              bit_size: 1
+            - name: rccalintstat
+              bit_offset: 8
+              bit_size: 1
+            - name: fifointstat
+              bit_offset: 15
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Dmintack1:
+          description: "DMINTACK1"
+          fields:
+            - name: clkntintack
+              bit_offset: 0
+              bit_size: 1
+            - name: slpintack
+              bit_offset: 1
+              bit_size: 1
+            - name: cryptintack
+              bit_offset: 2
+              bit_size: 1
+            - name: swintack
+              bit_offset: 3
+              bit_size: 1
+            - name: finetgtintack
+              bit_offset: 4
+              bit_size: 1
+            - name: timestamptgt1intack
+              bit_offset: 5
+              bit_size: 1
+            - name: timestamptgt2intack
+              bit_offset: 6
+              bit_size: 1
+            - name: timestamptgt3intack
+              bit_offset: 7
+              bit_size: 1
+            - name: rccalintack
+              bit_offset: 8
+              bit_size: 1
+            - name: fifointack
+              bit_offset: 15
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Actfifostat:
+          description: "ACTFIFOSTAT"
+          fields:
+            - name: startactintstat
+              bit_offset: 0
+              bit_size: 1
+            - name: endactintstat
+              bit_offset: 1
+              bit_size: 1
+            - name: skipactintstat
+              bit_offset: 2
+              bit_size: 1
+            - name: txintstat
+              bit_offset: 3
+              bit_size: 1
+            - name: rxintstat
+              bit_offset: 4
+              bit_size: 1
+            - name: isotxintstat
+              bit_offset: 5
+              bit_size: 1
+            - name: isorxintstat
+              bit_offset: 6
+              bit_size: 1
+            - name: actflag
+              bit_offset: 15
+              bit_size: 1
+            - name: current_et_idx
+              bit_offset: 24
+              bit_size: 4
+            - name: skip_et_idx
+              bit_offset: 28
+              bit_size: 4
+
+        fieldset/bt_mac::regs::Etptr:
+          description: "ETPTR"
+          fields:
+            - name: etptr
+              bit_offset: 0
+              bit_size: 14
+
+        fieldset/bt_mac::regs::Deepslcntl:
+          description: "DEEPSLCNTL"
+          fields:
+            - name: deep_sleep_corr_en
+              bit_offset: 3
+              bit_size: 1
+            - name: corr_mask_clknint
+              bit_offset: 4
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Finecntcorr:
+          description: "FINECNTCORR"
+          fields:
+            - name: finecntcorr
+              bit_offset: 0
+              bit_size: 10
+
+        fieldset/bt_mac::regs::Clkncntcorr:
+          description: "CLKNCNTCORR"
+          fields:
+            - name: clkncntcorr
+              bit_offset: 0
+              bit_size: 28
+            - name: abs_delta
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Dmdiagcntl:
+          description: "DMDIAGCNTL"
+          fields:
+            - name: diag0
+              bit_offset: 0
+              bit_size: 6
+            - name: diag0_en
+              bit_offset: 7
+              bit_size: 1
+            - name: diag1
+              bit_offset: 8
+              bit_size: 6
+            - name: diag1_en
+              bit_offset: 15
+              bit_size: 1
+            - name: diag2
+              bit_offset: 16
+              bit_size: 6
+            - name: diag2_en
+              bit_offset: 23
+              bit_size: 1
+            - name: diag3
+              bit_offset: 24
+              bit_size: 6
+            - name: diag3_en
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Dmdiagstat:
+          description: "DMDIAGSTAT"
+          fields:
+            - name: diag0stat
+              bit_offset: 0
+              bit_size: 8
+            - name: diag1stat
+              bit_offset: 8
+              bit_size: 8
+            - name: diag2stat
+              bit_offset: 16
+              bit_size: 8
+            - name: diag3stat
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Dmdebugaddmax:
+          description: "DMDEBUGADDMAX"
+          fields:
+            - name: em_addmax
+              bit_offset: 0
+              bit_size: 16
+            - name: reg_addmax
+              bit_offset: 16
+              bit_size: 16
+
+        fieldset/bt_mac::regs::Dmdebugaddmin:
+          description: "DMDEBUGADDMIN"
+          fields:
+            - name: em_addmin
+              bit_offset: 0
+              bit_size: 16
+            - name: reg_addmin
+              bit_offset: 16
+              bit_size: 16
+
+        fieldset/bt_mac::regs::Dmerrortypestat:
+          description: "DMERRORTYPESTAT"
+          fields:
+            - name: radio_emacc_error
+              bit_offset: 0
+              bit_size: 1
+            - name: fifowriteerr
+              bit_offset: 1
+              bit_size: 1
+            - name: act_schdl_entry_error
+              bit_offset: 2
+              bit_size: 1
+            - name: act_schdl_apfm_error
+              bit_offset: 3
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Dmswprofiling:
+          description: "DMSWPROFILING"
+          fields:
+            - name: swprof
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Dmradiocntl0:
+          description: "DMRADIOCNTL0"
+          fields:
+            - name: phy_rf_rxoff_delay
+              bit_offset: 0
+              bit_size: 8
+            - name: phy_rf_txoff_delay
+              bit_offset: 8
+              bit_size: 8
+            - name: phy_rxon_delay
+              bit_offset: 16
+              bit_size: 8
+            - name: phy_txon_delay
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Dmradiocntl1:
+          description: "DMRADIOCNTL1"
+          fields:
+            - name: rx_samp_dly
+              bit_offset: 4
+              bit_size: 4
+            - name: ext_master
+              bit_offset: 9
+              bit_size: 1
+            - name: ext_slave
+              bit_offset: 10
+              bit_size: 1
+            - name: dbgtrigsel
+              bit_offset: 11
+              bit_size: 3
+            - name: force_nbt_ble_val
+              bit_offset: 14
+              bit_size: 1
+            - name: force_nbt_ble
+              bit_offset: 15
+              bit_size: 1
+            - name: force_rate_val
+              bit_offset: 16
+              bit_size: 2
+            - name: force_rate
+              bit_offset: 18
+              bit_size: 1
+            - name: force_rx_val
+              bit_offset: 19
+              bit_size: 1
+            - name: force_rx
+              bit_offset: 20
+              bit_size: 1
+            - name: force_tx_val
+              bit_offset: 21
+              bit_size: 1
+            - name: force_tx
+              bit_offset: 22
+              bit_size: 1
+            - name: channel
+              bit_offset: 23
+              bit_size: 7
+            - name: force_channel
+              bit_offset: 30
+              bit_size: 1
+            - name: force_syncword
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Dmradiocntl2:
+          description: "DMRADIOCNTL2"
+          fields:
+            - name: syncword1
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Dmradiocntl3:
+          description: "DMRADIOCNTL3"
+          fields:
+            - name: syncword2
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Dmradiocntl4:
+          description: "DMRADIOCNTL4"
+          fields:
+            - name: chptr
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Aescntl:
+          description: "AESCNTL"
+          fields:
+            - name: aes_start
+              bit_offset: 0
+              bit_size: 1
+            - name: aes_mode
+              bit_offset: 1
+              bit_size: 1
+            - name: force_polar_pwr_val
+              bit_offset: 2
+              bit_size: 6
+            - name: force_polar_pwr
+              bit_offset: 8
+              bit_size: 1
+            - name: force_iq_pwr_val
+              bit_offset: 9
+              bit_size: 3
+            - name: force_iq_pwr
+              bit_offset: 12
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Aeskey310:
+          description: "AESKEY31_0"
+          fields:
+            - name: aeskey31_0
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Aeskey6332:
+          description: "AESKEY63_32"
+          fields:
+            - name: aeskey63_32
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Aeskey9564:
+          description: "AESKEY95_64"
+          fields:
+            - name: aeskey95_64
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Aeskey12796:
+          description: "AESKEY127_96"
+          fields:
+            - name: aeskey127_96
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Dmaesptr:
+          description: "DMAESPTR"
+          fields:
+            - name: aesptr
+              bit_offset: 0
+              bit_size: 16
+
+        fieldset/bt_mac::regs::Txmicval:
+          description: "TXMICVAL"
+          fields:
+            - name: txmicval
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Rxmicval:
+          description: "RXMICVAL"
+          fields:
+            - name: rxmicval
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Prioscharb:
+          description: "PRIOSCHARB"
+          fields:
+            - name: brpriomode
+              bit_offset: 0
+              bit_size: 1
+            - name: blepriomode
+              bit_offset: 16
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Dmtimgencntl:
+          description: "DMTIMGENCNTL"
+          fields:
+            - name: prefetch_time
+              bit_offset: 0
+              bit_size: 9
+            - name: prefetchabort_time
+              bit_offset: 16
+              bit_size: 10
+
+        fieldset/bt_mac::regs::Finetimtgt:
+          description: "FINETIMTGT"
+          fields:
+            - name: finetarget
+              bit_offset: 0
+              bit_size: 28
+
+        fieldset/bt_mac::regs::Clkntgt1:
+          description: "CLKNTGT1"
+          fields:
+            - name: clkntarget
+              bit_offset: 0
+              bit_size: 28
+
+        fieldset/bt_mac::regs::Hmicrosectgt1:
+          description: "HMICROSECTGT1"
+          fields:
+            - name: hmicrosectarget
+              bit_offset: 0
+              bit_size: 10
+
+        fieldset/bt_mac::regs::Clkntgt2:
+          description: "CLKNTGT2"
+          fields:
+            - name: clkntarget
+              bit_offset: 0
+              bit_size: 28
+
+        fieldset/bt_mac::regs::Hmicrosectgt2:
+          description: "HMICROSECTGT2"
+          fields:
+            - name: hmicrosectarget
+              bit_offset: 0
+              bit_size: 10
+
+        fieldset/bt_mac::regs::Clkntgt3:
+          description: "CLKNTGT3"
+          fields:
+            - name: clkntarget
+              bit_offset: 0
+              bit_size: 28
+
+        fieldset/bt_mac::regs::Hmicrosectgt3:
+          description: "HMICROSECTGT3"
+          fields:
+            - name: hmicrosectarget
+              bit_offset: 0
+              bit_size: 10
+
+        fieldset/bt_mac::regs::Slotclk:
+          description: "SLOTCLK"
+          fields:
+            - name: sclk
+              bit_offset: 0
+              bit_size: 28
+            - name: clkn_upd
+              bit_offset: 30
+              bit_size: 1
+            - name: samp
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Finetimecnt:
+          description: "FINETIMECNT"
+          fields:
+            - name: finecnt
+              bit_offset: 0
+              bit_size: 10
+
+        fieldset/bt_mac::regs::Actschcntl:
+          description: "ACTSCHCNTL"
+          fields:
+            - name: entry_idx
+              bit_offset: 0
+              bit_size: 4
+            - name: start_act
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::RccalCtrl:
+          description: "RCCAL_CTRL"
+          fields:
+            - name: rccal_length
+              bit_offset: 0
+              bit_size: 16
+            - name: rccal_auto
+              bit_offset: 16
+              bit_size: 1
+            - name: rccal_start
+              bit_offset: 17
+              bit_size: 1
+            - name: rccal_stop
+              bit_offset: 18
+              bit_size: 1
+            - name: con_num
+              bit_offset: 19
+              bit_size: 10
+            - name: con_mode
+              bit_offset: 29
+              bit_size: 1
+
+        fieldset/bt_mac::regs::RccalResult:
+          description: "RCCAL_RESULT"
+          fields:
+            - name: rccal_result
+              bit_offset: 0
+              bit_size: 31
+            - name: rccal_done
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Dfancntl:
+          description: "DFANCNTL"
+          fields:
+            - name: letxprimantid
+              bit_offset: 0
+              bit_size: 7
+            - name: letxprimidcntlen
+              bit_offset: 7
+              bit_size: 1
+            - name: lerxprimantid
+              bit_offset: 8
+              bit_size: 7
+            - name: lerxprimidcntlen
+              bit_offset: 15
+              bit_size: 1
+            - name: bttxprimantid
+              bit_offset: 16
+              bit_size: 7
+            - name: bttxprimidcntlen
+              bit_offset: 23
+              bit_size: 1
+            - name: btrxprimantid
+              bit_offset: 24
+              bit_size: 7
+            - name: btrxprimidcntlen
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Rwbtcntl:
+          description: "RWBTCNTL"
+          fields:
+            - name: nwinsize
+              bit_offset: 0
+              bit_size: 6
+            - name: hpdly_en
+              bit_offset: 6
+              bit_size: 1
+            - name: rwbten
+              bit_offset: 8
+              bit_size: 1
+            - name: cx_dnabort
+              bit_offset: 9
+              bit_size: 1
+            - name: cx_rxbsyena
+              bit_offset: 10
+              bit_size: 1
+            - name: cx_txbsyena
+              bit_offset: 11
+              bit_size: 1
+            - name: seqndsb
+              bit_offset: 12
+              bit_size: 1
+            - name: arqndsb
+              bit_offset: 13
+              bit_size: 1
+            - name: flowdsb
+              bit_offset: 14
+              bit_size: 1
+            - name: hopdsb
+              bit_offset: 15
+              bit_size: 1
+            - name: whitdsb
+              bit_offset: 16
+              bit_size: 1
+            - name: crcdsb
+              bit_offset: 17
+              bit_size: 1
+            - name: cryptdsb
+              bit_offset: 18
+              bit_size: 1
+            - name: lmpflowdsb
+              bit_offset: 19
+              bit_size: 1
+            - name: sniff_abort
+              bit_offset: 20
+              bit_size: 1
+            - name: pageing_abort
+              bit_offset: 21
+              bit_size: 1
+            - name: rftest_abort
+              bit_offset: 22
+              bit_size: 1
+            - name: scan_abort
+              bit_offset: 23
+              bit_size: 1
+            - name: master_soft_rst
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Btversion:
+          description: "BTVERSION"
+          fields:
+            - name: build_num
+              bit_offset: 0
+              bit_size: 8
+            - name: upg
+              bit_offset: 8
+              bit_size: 8
+            - name: rel
+              bit_offset: 16
+              bit_size: 8
+            - name: typ
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Btintcntl0:
+          description: "BTINTCNTL0"
+          fields:
+            - name: startfrmintmsk
+              bit_offset: 0
+              bit_size: 1
+            - name: endfrmintmsk
+              bit_offset: 1
+              bit_size: 1
+            - name: skipfrmintmsk
+              bit_offset: 2
+              bit_size: 1
+            - name: rxintmsk
+              bit_offset: 4
+              bit_size: 1
+            - name: frsyncintmsk
+              bit_offset: 8
+              bit_size: 1
+            - name: mtoffint0msk
+              bit_offset: 9
+              bit_size: 1
+            - name: mtoffint1msk
+              bit_offset: 10
+              bit_size: 1
+            - name: mwswcitxintmsk
+              bit_offset: 11
+              bit_size: 1
+            - name: mwswcirxintmsk
+              bit_offset: 12
+              bit_size: 1
+            - name: audio0intmsk
+              bit_offset: 13
+              bit_size: 1
+            - name: audio1intmsk
+              bit_offset: 14
+              bit_size: 1
+            - name: audio2intmsk
+              bit_offset: 15
+              bit_size: 1
+            - name: errorintmsk
+              bit_offset: 16
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Btintstat0:
+          description: "BTINTSTAT0"
+          fields:
+            - name: frsyncintstat
+              bit_offset: 8
+              bit_size: 1
+            - name: mtoffint0stat
+              bit_offset: 9
+              bit_size: 1
+            - name: mtoffint1stat
+              bit_offset: 10
+              bit_size: 1
+            - name: mwswcitxintstat
+              bit_offset: 11
+              bit_size: 1
+            - name: mwswcirxintstat
+              bit_offset: 12
+              bit_size: 1
+            - name: audio0intstat
+              bit_offset: 13
+              bit_size: 1
+            - name: audio1intstat
+              bit_offset: 14
+              bit_size: 1
+            - name: audio2intstat
+              bit_offset: 15
+              bit_size: 1
+            - name: errorintstat
+              bit_offset: 16
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Btintack0:
+          description: "BTINTACK0"
+          fields:
+            - name: frsyncintack
+              bit_offset: 8
+              bit_size: 1
+            - name: mtoffint0ack
+              bit_offset: 9
+              bit_size: 1
+            - name: mtoffint1ack
+              bit_offset: 10
+              bit_size: 1
+            - name: mwswcitxintack
+              bit_offset: 11
+              bit_size: 1
+            - name: mwswcirxintack
+              bit_offset: 12
+              bit_size: 1
+            - name: audio0intack
+              bit_offset: 13
+              bit_size: 1
+            - name: audio1intack
+              bit_offset: 14
+              bit_size: 1
+            - name: audio2intack
+              bit_offset: 15
+              bit_size: 1
+            - name: errorintack
+              bit_offset: 16
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Btcurrentrxdescptr:
+          description: "BTCURRENTRXDESCPTR"
+          fields:
+            - name: currentrxdescptr
+              bit_offset: 0
+              bit_size: 14
+
+        fieldset/bt_mac::regs::Btdiagcntl:
+          description: "BTDIAGCNTL"
+          fields:
+            - name: diag0
+              bit_offset: 0
+              bit_size: 7
+            - name: diag0_en
+              bit_offset: 7
+              bit_size: 1
+            - name: diag1
+              bit_offset: 8
+              bit_size: 7
+            - name: diag1_en
+              bit_offset: 15
+              bit_size: 1
+            - name: diag2
+              bit_offset: 16
+              bit_size: 7
+            - name: diag2_en
+              bit_offset: 23
+              bit_size: 1
+            - name: diag3
+              bit_offset: 24
+              bit_size: 7
+            - name: diag3_en
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Btdiagstat:
+          description: "BTDIAGSTAT"
+          fields:
+            - name: diag0stat
+              bit_offset: 0
+              bit_size: 8
+            - name: diag1stat
+              bit_offset: 8
+              bit_size: 8
+            - name: diag2stat
+              bit_offset: 16
+              bit_size: 8
+            - name: diag3stat
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Btdebugaddmax:
+          description: "BTDEBUGADDMAX"
+          fields:
+            - name: em_addmax
+              bit_offset: 0
+              bit_size: 16
+            - name: reg_addmax
+              bit_offset: 16
+              bit_size: 16
+
+        fieldset/bt_mac::regs::Btdebugaddmin:
+          description: "BTDEBUGADDMIN"
+          fields:
+            - name: em_addmin
+              bit_offset: 0
+              bit_size: 16
+            - name: reg_addmin
+              bit_offset: 16
+              bit_size: 16
+
+        fieldset/bt_mac::regs::Bterrortypestat:
+          description: "BTERRORTYPESTAT"
+          fields:
+            - name: txcrypt_error
+              bit_offset: 0
+              bit_size: 1
+            - name: rxcrypt_error
+              bit_offset: 1
+              bit_size: 1
+            - name: cryptmode_error
+              bit_offset: 2
+              bit_size: 1
+            - name: pktcntl_emacc_error
+              bit_offset: 3
+              bit_size: 1
+            - name: radio_emacc_error
+              bit_offset: 4
+              bit_size: 1
+            - name: audio_emacc_error
+              bit_offset: 5
+              bit_size: 1
+            - name: pcm_emacc_error
+              bit_offset: 6
+              bit_size: 1
+            - name: mwscoex_emacc_error
+              bit_offset: 7
+              bit_size: 1
+            - name: act_schdl_entry_error
+              bit_offset: 8
+              bit_size: 1
+            - name: act_schdl_apfm_error
+              bit_offset: 9
+              bit_size: 1
+            - name: frm_cntl_apfm_error
+              bit_offset: 10
+              bit_size: 1
+            - name: frm_cntl_emacc_error
+              bit_offset: 11
+              bit_size: 1
+            - name: frm_cntl_timer_error
+              bit_offset: 12
+              bit_size: 1
+            - name: hopunderrun_error
+              bit_offset: 13
+              bit_size: 1
+            - name: chmap_error
+              bit_offset: 14
+              bit_size: 1
+            - name: csformat_error
+              bit_offset: 15
+              bit_size: 1
+            - name: csattnb_error
+              bit_offset: 16
+              bit_size: 1
+            - name: txdesc_empty_error
+              bit_offset: 17
+              bit_size: 1
+            - name: rxdesc_empty_error
+              bit_offset: 18
+              bit_size: 1
+            - name: txbuf_ptr_error
+              bit_offset: 19
+              bit_size: 1
+            - name: rxbuf_ptr_error
+              bit_offset: 20
+              bit_size: 1
+            - name: peer_sam_error
+              bit_offset: 21
+              bit_size: 1
+            - name: local_sam_error
+              bit_offset: 22
+              bit_size: 1
+            - name: fifointovf
+              bit_offset: 23
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Btswprofiling:
+          description: "BTSWPROFILING"
+          fields:
+            - name: swprof
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Btradiocntl2:
+          description: "BTRADIOCNTL2"
+          fields:
+            - name: freqtable_ptr
+              bit_offset: 0
+              bit_size: 14
+            - name: trailer_gating_val
+              bit_offset: 24
+              bit_size: 3
+
+        fieldset/bt_mac::regs::Btradiocntl3:
+          description: "BTRADIOCNTL3"
+          fields:
+            - name: txrate0cfg
+              bit_offset: 8
+              bit_size: 2
+            - name: txrate1cfg
+              bit_offset: 10
+              bit_size: 2
+            - name: txrate2cfg
+              bit_offset: 12
+              bit_size: 2
+            - name: rxrate0cfg
+              bit_offset: 24
+              bit_size: 2
+            - name: rxrate1cfg
+              bit_offset: 26
+              bit_size: 2
+            - name: rxrate2cfg
+              bit_offset: 28
+              bit_size: 2
+
+        fieldset/bt_mac::regs::Btradiopwrupdn:
+          description: "BTRADIOPWRUPDN"
+          fields:
+            - name: txpwrupct
+              bit_offset: 0
+              bit_size: 8
+            - name: txpwrdnct
+              bit_offset: 8
+              bit_size: 7
+            - name: rxpwrupct
+              bit_offset: 16
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Btradiotxrxtim:
+          description: "BTRADIOTXRXTIM"
+          fields:
+            - name: txpathdly
+              bit_offset: 0
+              bit_size: 7
+            - name: rxpathdly
+              bit_offset: 8
+              bit_size: 7
+            - name: sync_position
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Btrftestcntl:
+          description: "BTRFTESTCNTL"
+          fields:
+            - name: txpktcnten
+              bit_offset: 11
+              bit_size: 1
+            - name: txpldsrc
+              bit_offset: 12
+              bit_size: 1
+            - name: prbstype
+              bit_offset: 13
+              bit_size: 1
+            - name: infinitetx
+              bit_offset: 15
+              bit_size: 1
+            - name: herrren
+              bit_offset: 16
+              bit_size: 1
+            - name: sserrren
+              bit_offset: 17
+              bit_size: 1
+            - name: percount_mode
+              bit_offset: 24
+              bit_size: 3
+            - name: rxpktcnten
+              bit_offset: 27
+              bit_size: 1
+            - name: infiniterx
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Btrftestfreq:
+          description: "BTRFTESTFREQ"
+          fields:
+            - name: txfreq
+              bit_offset: 0
+              bit_size: 7
+            - name: rxfreq
+              bit_offset: 8
+              bit_size: 7
+            - name: testmodeen
+              bit_offset: 16
+              bit_size: 1
+            - name: directloopbacken
+              bit_offset: 17
+              bit_size: 1
+            - name: loopback_mode
+              bit_offset: 18
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Btrftesttxstat:
+          description: "BTRFTESTTXSTAT"
+          fields:
+            - name: txpktcnt
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Btrftestrxstat:
+          description: "BTRFTESTRXSTAT"
+          fields:
+            - name: rxpktcnt
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Startfrmclknts:
+          description: "STARTFRMCLKNTS"
+          fields:
+            - name: startfrmclknts
+              bit_offset: 0
+              bit_size: 28
+
+        fieldset/bt_mac::regs::Startfrmfinecntts:
+          description: "STARTFRMFINECNTTS"
+          fields:
+            - name: startfrmfinecntts
+              bit_offset: 0
+              bit_size: 10
+
+        fieldset/bt_mac::regs::Endfrmclknts:
+          description: "ENDFRMCLKNTS"
+          fields:
+            - name: endfrmclknts
+              bit_offset: 0
+              bit_size: 28
+
+        fieldset/bt_mac::regs::Endfrmfinecntts:
+          description: "ENDFRMFINECNTTS"
+          fields:
+            - name: endfrmfinecntts
+              bit_offset: 0
+              bit_size: 10
+
+        fieldset/bt_mac::regs::Skipfrmclknts:
+          description: "SKIPFRMCLKNTS"
+          fields:
+            - name: skipfrmclknts
+              bit_offset: 0
+              bit_size: 28
+
+        fieldset/bt_mac::regs::Skipfrmfinecntts:
+          description: "SKIPFRMFINECNTTS"
+          fields:
+            - name: skipfrmfinecntts
+              bit_offset: 0
+              bit_size: 10
+
+        fieldset/bt_mac::regs::Abtraincntl:
+          description: "ABTRAINCNTL"
+          fields:
+            - name: abtinqtime
+              bit_offset: 0
+              bit_size: 11
+            - name: abtinqload
+              bit_offset: 12
+              bit_size: 1
+            - name: abtinqstartvalue
+              bit_offset: 14
+              bit_size: 1
+            - name: abtinqen
+              bit_offset: 15
+              bit_size: 1
+            - name: abtpagetime
+              bit_offset: 16
+              bit_size: 11
+            - name: abtpageload
+              bit_offset: 28
+              bit_size: 1
+            - name: abtpagestartvalue
+              bit_offset: 30
+              bit_size: 1
+            - name: abtpageen
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Edrcntl:
+          description: "EDRCNTL"
+          fields:
+            - name: rxgrd_timeout
+              bit_offset: 0
+              bit_size: 6
+            - name: gb_txqual_gen_dsb
+              bit_offset: 6
+              bit_size: 1
+            - name: rxguarddsb
+              bit_offset: 7
+              bit_size: 1
+            - name: guard_band_time
+              bit_offset: 8
+              bit_size: 3
+            - name: tx_swap
+              bit_offset: 12
+              bit_size: 1
+            - name: rx_swap
+              bit_offset: 13
+              bit_size: 1
+            - name: edrbcast
+              bit_offset: 15
+              bit_size: 1
+            - name: txrate_swinstant
+              bit_offset: 16
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Pcacntl0:
+          description: "PCACNTL0"
+          fields:
+            - name: phase_shift_en
+              bit_offset: 0
+              bit_size: 1
+            - name: sync_source
+              bit_offset: 1
+              bit_size: 1
+            - name: frsync_pol
+              bit_offset: 2
+              bit_size: 1
+            - name: blindcorr_en
+              bit_offset: 3
+              bit_size: 1
+            - name: corr_step
+              bit_offset: 4
+              bit_size: 4
+            - name: slvlbl
+              bit_offset: 8
+              bit_size: 5
+            - name: target_offset
+              bit_offset: 16
+              bit_size: 11
+
+        fieldset/bt_mac::regs::Pcacntl1:
+          description: "PCACNTL1"
+          fields:
+            - name: clock_shift
+              bit_offset: 0
+              bit_size: 11
+            - name: clock_shift_en
+              bit_offset: 12
+              bit_size: 1
+            - name: corr_interval
+              bit_offset: 16
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Pcastat:
+          description: "PCASTAT"
+          fields:
+            - name: moment_offset
+              bit_offset: 0
+              bit_size: 11
+            - name: shift_phase
+              bit_offset: 16
+              bit_size: 11
+
+        fieldset/bt_mac::regs::Btcoexifcntl0:
+          description: "BTCOEXIFCNTL0"
+          fields:
+            - name: wlancoex_en
+              bit_offset: 0
+              bit_size: 1
+            - name: syncgen_en
+              bit_offset: 1
+              bit_size: 1
+            - name: mwscoex_en
+              bit_offset: 2
+              bit_size: 1
+            - name: mwswci_en
+              bit_offset: 3
+              bit_size: 1
+            - name: wlanrxmsk
+              bit_offset: 4
+              bit_size: 2
+            - name: wlantxmsk
+              bit_offset: 6
+              bit_size: 2
+            - name: mwsrxmsk
+              bit_offset: 8
+              bit_size: 2
+            - name: mwstxmsk
+              bit_offset: 10
+              bit_size: 2
+            - name: mwsrxfreqmsk
+              bit_offset: 12
+              bit_size: 2
+            - name: mwstxfreqmsk
+              bit_offset: 14
+              bit_size: 2
+            - name: wlctxpriomode
+              bit_offset: 16
+              bit_size: 2
+            - name: wlcrxpriomode
+              bit_offset: 18
+              bit_size: 2
+            - name: mwsscanfreqmsk
+              bit_offset: 20
+              bit_size: 2
+            - name: pageeknudgeinc
+              bit_offset: 24
+              bit_size: 4
+            - name: inqknudgeinc
+              bit_offset: 28
+              bit_size: 4
+
+        fieldset/bt_mac::regs::Btcoexifcntl1:
+          description: "BTCOEXIFCNTL1"
+          fields:
+            - name: wlcpdelay
+              bit_offset: 0
+              bit_size: 7
+            - name: wlcpduration
+              bit_offset: 8
+              bit_size: 7
+            - name: wlcptxthr
+              bit_offset: 16
+              bit_size: 5
+            - name: wlcprxthr
+              bit_offset: 24
+              bit_size: 5
+
+        fieldset/bt_mac::regs::Btcoexifcntl2:
+          description: "BTCOEXIFCNTL2"
+          fields:
+            - name: tx_ant_delay
+              bit_offset: 0
+              bit_size: 4
+            - name: rx_ant_delay
+              bit_offset: 8
+              bit_size: 4
+            - name: pta_force_val
+              bit_offset: 13
+              bit_size: 3
+            - name: pta_actsel
+              bit_offset: 16
+              bit_size: 2
+            - name: pta_actmode
+              bit_offset: 18
+              bit_size: 1
+            - name: pta_actpol
+              bit_offset: 19
+              bit_size: 1
+            - name: pta_priomode
+              bit_offset: 20
+              bit_size: 1
+            - name: pta_abortmode
+              bit_offset: 21
+              bit_size: 1
+            - name: pta_wlanpol
+              bit_offset: 22
+              bit_size: 1
+            - name: pta_aborttx
+              bit_offset: 23
+              bit_size: 1
+            - name: pta_abortrx
+              bit_offset: 24
+              bit_size: 1
+            - name: pta_masktx
+              bit_offset: 25
+              bit_size: 1
+            - name: pta_maskrx
+              bit_offset: 26
+              bit_size: 1
+            - name: pta_wlantx
+              bit_offset: 27
+              bit_size: 1
+            - name: pta_wlanrx
+              bit_offset: 28
+              bit_size: 1
+            - name: pta_force_en
+              bit_offset: 29
+              bit_size: 3
+
+        fieldset/bt_mac::regs::Btmprio0:
+          description: "BTMPRIO0"
+          fields:
+            - name: btm0
+              bit_offset: 0
+              bit_size: 4
+            - name: btm1
+              bit_offset: 4
+              bit_size: 4
+            - name: btm2
+              bit_offset: 8
+              bit_size: 4
+            - name: btm3
+              bit_offset: 12
+              bit_size: 4
+            - name: btm4
+              bit_offset: 16
+              bit_size: 4
+            - name: btm5
+              bit_offset: 20
+              bit_size: 4
+            - name: btm6
+              bit_offset: 24
+              bit_size: 4
+            - name: btm7
+              bit_offset: 28
+              bit_size: 4
+
+        fieldset/bt_mac::regs::Btmprio1:
+          description: "BTMPRIO1"
+          fields:
+            - name: btm8
+              bit_offset: 0
+              bit_size: 4
+            - name: btm9
+              bit_offset: 4
+              bit_size: 4
+            - name: btm10
+              bit_offset: 8
+              bit_size: 4
+            - name: btm11
+              bit_offset: 12
+              bit_size: 4
+            - name: btm12
+              bit_offset: 16
+              bit_size: 4
+            - name: btm13
+              bit_offset: 20
+              bit_size: 4
+            - name: btm14
+              bit_offset: 24
+              bit_size: 4
+            - name: btm15
+              bit_offset: 28
+              bit_size: 4
+
+        fieldset/bt_mac::regs::Btmprio2:
+          description: "BTMPRIO2"
+          fields:
+            - name: btm16
+              bit_offset: 0
+              bit_size: 4
+            - name: btm17
+              bit_offset: 4
+              bit_size: 4
+            - name: btm18
+              bit_offset: 8
+              bit_size: 4
+            - name: btm19
+              bit_offset: 12
+              bit_size: 4
+            - name: btm20
+              bit_offset: 16
+              bit_size: 4
+            - name: btmdefault
+              bit_offset: 28
+              bit_size: 4
+
+        fieldset/bt_mac::regs::Coexchn0:
+          description: "COEXCHN0"
+          fields:
+            - name: coexchn31_0
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Coexchn1:
+          description: "COEXCHN1"
+          fields:
+            - name: coexchn63_32
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Coexchn2:
+          description: "COEXCHN2"
+          fields:
+            - name: coexchn78_64
+              bit_offset: 0
+              bit_size: 15
+
+        fieldset/bt_mac::regs::Escochancntl0:
+          description: "ESCOCHANCNTL0"
+          fields:
+            - name: tesco0
+              bit_offset: 0
+              bit_size: 8
+            - name: intdelay0
+              bit_offset: 8
+              bit_size: 5
+            - name: itmode0
+              bit_offset: 13
+              bit_size: 1
+            - name: escochanen0
+              bit_offset: 14
+              bit_size: 1
+            - name: escochanswen0
+              bit_offset: 15
+              bit_size: 1
+            - name: tog0
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Escomutecntl0:
+          description: "ESCOMUTECNTL0"
+          fields:
+            - name: mutepatt0
+              bit_offset: 0
+              bit_size: 16
+            - name: invl0_0
+              bit_offset: 16
+              bit_size: 2
+            - name: invl0_1
+              bit_offset: 18
+              bit_size: 2
+            - name: mute_source0
+              bit_offset: 22
+              bit_size: 1
+            - name: mute_sink0
+              bit_offset: 23
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Escocurrenttxptr0:
+          description: "ESCOCURRENTTXPTR0"
+          fields:
+            - name: esco0ptrtx0
+              bit_offset: 0
+              bit_size: 16
+            - name: esco0ptrtx1
+              bit_offset: 16
+              bit_size: 16
+
+        fieldset/bt_mac::regs::Escocurrentrxptr0:
+          description: "ESCOCURRENTRXPTR0"
+          fields:
+            - name: esco0ptrrx0
+              bit_offset: 0
+              bit_size: 16
+            - name: esco0ptrrx1
+              bit_offset: 16
+              bit_size: 16
+
+        fieldset/bt_mac::regs::Escoltcntl0:
+          description: "ESCOLTCNTL0"
+          fields:
+            - name: synltaddr0
+              bit_offset: 0
+              bit_size: 3
+            - name: syntype0
+              bit_offset: 3
+              bit_size: 1
+            - name: escoedrtx0
+              bit_offset: 4
+              bit_size: 1
+            - name: escoedrrx0
+              bit_offset: 5
+              bit_size: 1
+            - name: retxnb0
+              bit_offset: 16
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Escotrcntl0:
+          description: "ESCOTRCNTL0"
+          fields:
+            - name: rxtype0
+              bit_offset: 0
+              bit_size: 4
+            - name: rxlen0
+              bit_offset: 4
+              bit_size: 10
+            - name: txtype0
+              bit_offset: 16
+              bit_size: 4
+            - name: txlen0
+              bit_offset: 20
+              bit_size: 10
+            - name: txseqn0
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Escodaycnt0:
+          description: "ESCODAYCNT0"
+          fields:
+            - name: dayconter0
+              bit_offset: 0
+              bit_size: 11
+
+        fieldset/bt_mac::regs::Escochancntl1:
+          description: "ESCOCHANCNTL1"
+          fields:
+            - name: tesco1
+              bit_offset: 0
+              bit_size: 8
+            - name: intdelay1
+              bit_offset: 8
+              bit_size: 5
+            - name: itmode1
+              bit_offset: 13
+              bit_size: 1
+            - name: escochanen1
+              bit_offset: 14
+              bit_size: 1
+            - name: escochanswen1
+              bit_offset: 15
+              bit_size: 1
+            - name: tog1
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Escomutecntl1:
+          description: "ESCOMUTECNTL1"
+          fields:
+            - name: mutepatt1
+              bit_offset: 0
+              bit_size: 16
+            - name: invl1_0
+              bit_offset: 16
+              bit_size: 2
+            - name: invl1_1
+              bit_offset: 18
+              bit_size: 2
+            - name: mute_source1
+              bit_offset: 22
+              bit_size: 1
+            - name: mute_sink1
+              bit_offset: 23
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Escocurrenttxptr1:
+          description: "ESCOCURRENTTXPTR1"
+          fields:
+            - name: esco1ptrtx0
+              bit_offset: 0
+              bit_size: 16
+            - name: esco1ptrtx1
+              bit_offset: 16
+              bit_size: 16
+
+        fieldset/bt_mac::regs::Escocurrentrxptr1:
+          description: "ESCOCURRENTRXPTR1"
+          fields:
+            - name: esco1ptrrx0
+              bit_offset: 0
+              bit_size: 16
+            - name: esco1ptrrx1
+              bit_offset: 16
+              bit_size: 16
+
+        fieldset/bt_mac::regs::Escoltcntl1:
+          description: "ESCOLTCNTL1"
+          fields:
+            - name: synltaddr1
+              bit_offset: 0
+              bit_size: 3
+            - name: syntype1
+              bit_offset: 3
+              bit_size: 1
+            - name: escoedrtx1
+              bit_offset: 4
+              bit_size: 1
+            - name: escoedrrx1
+              bit_offset: 5
+              bit_size: 1
+            - name: retxnb1
+              bit_offset: 16
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Escotrcntl1:
+          description: "ESCOTRCNTL1"
+          fields:
+            - name: rxtype1
+              bit_offset: 0
+              bit_size: 4
+            - name: rxlen1
+              bit_offset: 4
+              bit_size: 10
+            - name: txtype1
+              bit_offset: 16
+              bit_size: 4
+            - name: txlen1
+              bit_offset: 20
+              bit_size: 10
+            - name: txseqn1
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Escodaycnt1:
+          description: "ESCODAYCNT1"
+          fields:
+            - name: dayconter1
+              bit_offset: 0
+              bit_size: 11
+
+        fieldset/bt_mac::regs::Escochancntl2:
+          description: "ESCOCHANCNTL2"
+          fields:
+            - name: tesco2
+              bit_offset: 0
+              bit_size: 8
+            - name: intdelay2
+              bit_offset: 8
+              bit_size: 5
+            - name: itmode2
+              bit_offset: 13
+              bit_size: 1
+            - name: escochanen2
+              bit_offset: 14
+              bit_size: 1
+            - name: escochanswen2
+              bit_offset: 15
+              bit_size: 1
+            - name: tog2
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Escomutecntl2:
+          description: "ESCOMUTECNTL2"
+          fields:
+            - name: mutepatt2
+              bit_offset: 0
+              bit_size: 16
+            - name: invl2_0
+              bit_offset: 16
+              bit_size: 2
+            - name: invl2_1
+              bit_offset: 18
+              bit_size: 2
+            - name: mute_source2
+              bit_offset: 22
+              bit_size: 1
+            - name: mute_sink2
+              bit_offset: 23
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Escocurrenttxptr2:
+          description: "ESCOCURRENTTXPTR2"
+          fields:
+            - name: esco2ptrtx0
+              bit_offset: 0
+              bit_size: 16
+            - name: esco2ptrtx1
+              bit_offset: 16
+              bit_size: 16
+
+        fieldset/bt_mac::regs::Escocurrentrxptr2:
+          description: "ESCOCURRENTRXPTR2"
+          fields:
+            - name: esco2ptrrx0
+              bit_offset: 0
+              bit_size: 16
+            - name: esco2ptrrx1
+              bit_offset: 16
+              bit_size: 16
+
+        fieldset/bt_mac::regs::Escoltcntl2:
+          description: "ESCOLTCNTL2"
+          fields:
+            - name: synltaddr2
+              bit_offset: 0
+              bit_size: 3
+            - name: syntype2
+              bit_offset: 3
+              bit_size: 1
+            - name: escoedrtx2
+              bit_offset: 4
+              bit_size: 1
+            - name: escoedrrx2
+              bit_offset: 5
+              bit_size: 1
+            - name: retxnb2
+              bit_offset: 16
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Escotrcntl2:
+          description: "ESCOTRCNTL2"
+          fields:
+            - name: rxtype2
+              bit_offset: 0
+              bit_size: 4
+            - name: rxlen2
+              bit_offset: 4
+              bit_size: 10
+            - name: txtype2
+              bit_offset: 16
+              bit_size: 4
+            - name: txlen2
+              bit_offset: 20
+              bit_size: 10
+            - name: txseqn2
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Escodaycnt2:
+          description: "ESCODAYCNT2"
+          fields:
+            - name: dayconter2
+              bit_offset: 0
+              bit_size: 11
+
+        fieldset/bt_mac::regs::Audiocntl0:
+          description: "AUDIOCNTL0"
+          fields:
+            - name: cvsd_bitoder0
+              bit_offset: 0
+              bit_size: 1
+            - name: cvsden0
+              bit_offset: 7
+              bit_size: 1
+            - name: aulaw_code0
+              bit_offset: 8
+              bit_size: 4
+            - name: aulawen0
+              bit_offset: 15
+              bit_size: 1
+            - name: sample_type0
+              bit_offset: 16
+              bit_size: 2
+            - name: linear_format0
+              bit_offset: 20
+              bit_size: 2
+
+        fieldset/bt_mac::regs::Audiocntl1:
+          description: "AUDIOCNTL1"
+          fields:
+            - name: cvsd_bitoder1
+              bit_offset: 0
+              bit_size: 1
+            - name: cvsden1
+              bit_offset: 7
+              bit_size: 1
+            - name: aulaw_code1
+              bit_offset: 8
+              bit_size: 4
+            - name: aulawen1
+              bit_offset: 15
+              bit_size: 1
+            - name: sample_type1
+              bit_offset: 16
+              bit_size: 2
+            - name: linear_format1
+              bit_offset: 20
+              bit_size: 2
+
+        fieldset/bt_mac::regs::Audiocntl2:
+          description: "AUDIOCNTL2"
+          fields:
+            - name: cvsd_bitoder2
+              bit_offset: 0
+              bit_size: 1
+            - name: cvsden2
+              bit_offset: 7
+              bit_size: 1
+            - name: aulaw_code2
+              bit_offset: 8
+              bit_size: 4
+            - name: aulawen2
+              bit_offset: 15
+              bit_size: 1
+            - name: sample_type2
+              bit_offset: 16
+              bit_size: 2
+            - name: linear_format2
+              bit_offset: 20
+              bit_size: 2
+
+        fieldset/bt_mac::regs::Rwblecntl:
+          description: "RWBLECNTL"
+          fields:
+            - name: rxwinszdef
+              bit_offset: 0
+              bit_size: 4
+            - name: rwble_en
+              bit_offset: 8
+              bit_size: 1
+            - name: advertfilt_en
+              bit_offset: 9
+              bit_size: 1
+            - name: anonymous_adv_filt_en
+              bit_offset: 10
+              bit_size: 1
+            - name: rxcteerr_rety_en
+              bit_offset: 11
+              bit_size: 1
+            - name: hop_remap_dsb
+              bit_offset: 12
+              bit_size: 1
+            - name: crc_dsb
+              bit_offset: 13
+              bit_size: 1
+            - name: whit_dsb
+              bit_offset: 14
+              bit_size: 1
+            - name: lrfec_dsb
+              bit_offset: 15
+              bit_size: 1
+            - name: lrpmap_dsb
+              bit_offset: 16
+              bit_size: 1
+            - name: crypt_dsb
+              bit_offset: 17
+              bit_size: 1
+            - name: nesn_dsb
+              bit_offset: 18
+              bit_size: 1
+            - name: sn_dsb
+              bit_offset: 19
+              bit_size: 1
+            - name: md_dsb
+              bit_offset: 20
+              bit_size: 1
+            - name: npi_dsb
+              bit_offset: 21
+              bit_size: 1
+            - name: cie_dsb
+              bit_offset: 22
+              bit_size: 1
+            - name: scan_abort
+              bit_offset: 24
+              bit_size: 1
+            - name: advert_abort
+              bit_offset: 25
+              bit_size: 1
+            - name: rftest_abort
+              bit_offset: 26
+              bit_size: 1
+            - name: master_soft_rst
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Bleversion:
+          description: "BLEVERSION"
+          fields:
+            - name: build_num
+              bit_offset: 0
+              bit_size: 8
+            - name: upg
+              bit_offset: 8
+              bit_size: 8
+            - name: rel
+              bit_offset: 16
+              bit_size: 8
+            - name: typ
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Bleintcntl0:
+          description: "BLEINTCNTL0"
+          fields:
+            - name: startevtintmsk
+              bit_offset: 0
+              bit_size: 1
+            - name: endevtintmsk
+              bit_offset: 1
+              bit_size: 1
+            - name: skipevtintmsk
+              bit_offset: 2
+              bit_size: 1
+            - name: txintmsk
+              bit_offset: 3
+              bit_size: 1
+            - name: rxintmsk
+              bit_offset: 4
+              bit_size: 1
+            - name: isotxintmsk
+              bit_offset: 5
+              bit_size: 1
+            - name: isorxintmsk
+              bit_offset: 6
+              bit_size: 1
+            - name: hopintmsk
+              bit_offset: 7
+              bit_size: 1
+            - name: errorintmsk
+              bit_offset: 16
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Bleintstat0:
+          description: "BLEINTSTAT0"
+          fields:
+            - name: hopintstat
+              bit_offset: 7
+              bit_size: 1
+            - name: errorintstat
+              bit_offset: 16
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Bleintack0:
+          description: "BLEINTACK0"
+          fields:
+            - name: hopintack
+              bit_offset: 7
+              bit_size: 1
+            - name: errorintack
+              bit_offset: 16
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Blecurrentrxdescptr:
+          description: "BLECURRENTRXDESCPTR"
+          fields:
+            - name: currentrxdescptr
+              bit_offset: 0
+              bit_size: 14
+
+        fieldset/bt_mac::regs::Blediagcntl:
+          description: "BLEDIAGCNTL"
+          fields:
+            - name: diag0
+              bit_offset: 0
+              bit_size: 7
+            - name: diag0_en
+              bit_offset: 7
+              bit_size: 1
+            - name: diag1
+              bit_offset: 8
+              bit_size: 7
+            - name: diag1_en
+              bit_offset: 15
+              bit_size: 1
+            - name: diag2
+              bit_offset: 16
+              bit_size: 7
+            - name: diag2_en
+              bit_offset: 23
+              bit_size: 1
+            - name: diag3
+              bit_offset: 24
+              bit_size: 7
+            - name: diag3_en
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Blediagstat:
+          description: "BLEDIAGSTAT"
+          fields:
+            - name: diag0stat
+              bit_offset: 0
+              bit_size: 8
+            - name: diag1stat
+              bit_offset: 8
+              bit_size: 8
+            - name: diag2stat
+              bit_offset: 16
+              bit_size: 8
+            - name: diag3stat
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Bledebugaddmax:
+          description: "BLEDEBUGADDMAX"
+          fields:
+            - name: em_addmax
+              bit_offset: 0
+              bit_size: 16
+            - name: reg_addmax
+              bit_offset: 16
+              bit_size: 16
+
+        fieldset/bt_mac::regs::Bledebugaddmin:
+          description: "BLEDEBUGADDMIN"
+          fields:
+            - name: em_addmin
+              bit_offset: 0
+              bit_size: 16
+            - name: reg_addmin
+              bit_offset: 16
+              bit_size: 16
+
+        fieldset/bt_mac::regs::Bleerrortypestat:
+          description: "BLEERRORTYPESTAT"
+          fields:
+            - name: txcrypt_error
+              bit_offset: 0
+              bit_size: 1
+            - name: rxcrypt_error
+              bit_offset: 1
+              bit_size: 1
+            - name: pktcntl_emacc_error
+              bit_offset: 2
+              bit_size: 1
+            - name: radio_emacc_error
+              bit_offset: 3
+              bit_size: 1
+            - name: act_schdl_entry_error
+              bit_offset: 4
+              bit_size: 1
+            - name: act_schdl_apfm_error
+              bit_offset: 5
+              bit_size: 1
+            - name: evt_cntl_apfm_error
+              bit_offset: 6
+              bit_size: 1
+            - name: list_error
+              bit_offset: 7
+              bit_size: 1
+            - name: ifs_underrun
+              bit_offset: 8
+              bit_size: 1
+            - name: adv_underrun
+              bit_offset: 9
+              bit_size: 1
+            - name: llchmap_error
+              bit_offset: 10
+              bit_size: 1
+            - name: csformat_error
+              bit_offset: 11
+              bit_size: 1
+            - name: txdesc_empty_error
+              bit_offset: 12
+              bit_size: 1
+            - name: rxdesc_empty_error
+              bit_offset: 13
+              bit_size: 1
+            - name: txdata_ptr_error
+              bit_offset: 14
+              bit_size: 1
+            - name: rxdata_ptr_error
+              bit_offset: 15
+              bit_size: 1
+            - name: ral_error
+              bit_offset: 16
+              bit_size: 1
+            - name: ral_underrun
+              bit_offset: 17
+              bit_size: 1
+            - name: tmafs_underrun
+              bit_offset: 18
+              bit_size: 1
+            - name: txaeheader_ptr_error
+              bit_offset: 19
+              bit_size: 1
+            - name: phy_error
+              bit_offset: 20
+              bit_size: 1
+            - name: fifointovf
+              bit_offset: 21
+              bit_size: 1
+            - name: dfcntl_emacc_error
+              bit_offset: 22
+              bit_size: 1
+            - name: freqsel_error
+              bit_offset: 23
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Bleswprofiling:
+          description: "BLESWPROFILING"
+          fields:
+            - name: swprof
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Bleradiocntl2:
+          description: "BLERADIOCNTL2"
+          fields:
+            - name: freqtable_ptr
+              bit_offset: 0
+              bit_size: 14
+            - name: phymsk
+              bit_offset: 22
+              bit_size: 2
+
+        fieldset/bt_mac::regs::Bleradiocntl3:
+          description: "BLERADIOCNTL3"
+          fields:
+            - name: txrate0cfg
+              bit_offset: 8
+              bit_size: 2
+            - name: txrate1cfg
+              bit_offset: 10
+              bit_size: 2
+            - name: txrate2cfg
+              bit_offset: 12
+              bit_size: 2
+            - name: txrate3cfg
+              bit_offset: 14
+              bit_size: 2
+            - name: rxrate0cfg
+              bit_offset: 24
+              bit_size: 2
+            - name: rxrate1cfg
+              bit_offset: 26
+              bit_size: 2
+            - name: rxrate2cfg
+              bit_offset: 28
+              bit_size: 2
+            - name: rxrate3cfg
+              bit_offset: 30
+              bit_size: 2
+
+        fieldset/bt_mac::regs::Bleradiopwrupdn0:
+          description: "BLERADIOPWRUPDN0"
+          fields:
+            - name: txpwrup0
+              bit_offset: 0
+              bit_size: 8
+            - name: txpwrdn0
+              bit_offset: 8
+              bit_size: 7
+            - name: rxpwrup0
+              bit_offset: 16
+              bit_size: 8
+            - name: sync_position0
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Bleradiopwrupdn1:
+          description: "BLERADIOPWRUPDN1"
+          fields:
+            - name: txpwrup1
+              bit_offset: 0
+              bit_size: 8
+            - name: txpwrdn1
+              bit_offset: 8
+              bit_size: 7
+            - name: rxpwrup1
+              bit_offset: 16
+              bit_size: 8
+            - name: sync_position1
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Bleradiopwrupdn2:
+          description: "BLERADIOPWRUPDN2"
+          fields:
+            - name: txpwrup2
+              bit_offset: 0
+              bit_size: 8
+            - name: txpwrdn2
+              bit_offset: 8
+              bit_size: 7
+            - name: rxpwrup2
+              bit_offset: 16
+              bit_size: 8
+            - name: sync_position2
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Bleradiopwrupdn3:
+          description: "BLERADIOPWRUPDN3"
+          fields:
+            - name: txpwrup3
+              bit_offset: 0
+              bit_size: 8
+            - name: txpwrdn3
+              bit_offset: 8
+              bit_size: 7
+
+        fieldset/bt_mac::regs::Bleradiotxrxtim0:
+          description: "BLERADIOTXRXTIM0"
+          fields:
+            - name: txpathdly0
+              bit_offset: 0
+              bit_size: 7
+            - name: rxpathdly0
+              bit_offset: 8
+              bit_size: 7
+            - name: rfrxtmda0
+              bit_offset: 16
+              bit_size: 7
+
+        fieldset/bt_mac::regs::Bleradiotxrxtim1:
+          description: "BLERADIOTXRXTIM1"
+          fields:
+            - name: txpathdly1
+              bit_offset: 0
+              bit_size: 7
+            - name: rxpathdly1
+              bit_offset: 8
+              bit_size: 7
+            - name: rfrxtmda1
+              bit_offset: 16
+              bit_size: 7
+
+        fieldset/bt_mac::regs::Bleradiotxrxtim2:
+          description: "BLERADIOTXRXTIM2"
+          fields:
+            - name: txpathdly2
+              bit_offset: 0
+              bit_size: 7
+            - name: rxpathdly2
+              bit_offset: 8
+              bit_size: 8
+            - name: rfrxtmda2
+              bit_offset: 16
+              bit_size: 8
+            - name: rxflushpathdly2
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Bleradiotxrxtim3:
+          description: "BLERADIOTXRXTIM3"
+          fields:
+            - name: txpathdly3
+              bit_offset: 0
+              bit_size: 7
+            - name: rfrxtmda3
+              bit_offset: 16
+              bit_size: 7
+            - name: rxflushpathdly3
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Blerftestcntl:
+          description: "BLERFTESTCNTL"
+          fields:
+            - name: txlength
+              bit_offset: 0
+              bit_size: 8
+            - name: txpktcnten
+              bit_offset: 11
+              bit_size: 1
+            - name: txpldsrc
+              bit_offset: 12
+              bit_size: 1
+            - name: prbstype
+              bit_offset: 13
+              bit_size: 1
+            - name: txlengthsrc
+              bit_offset: 14
+              bit_size: 1
+            - name: infinitetx
+              bit_offset: 15
+              bit_size: 1
+            - name: percount_mode
+              bit_offset: 24
+              bit_size: 2
+            - name: rxpktcnten
+              bit_offset: 27
+              bit_size: 1
+            - name: infiniterx
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Blerftesttxstat:
+          description: "BLERFTESTTXSTAT"
+          fields:
+            - name: txpktcnt
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Blerftestrxstat:
+          description: "BLERFTESTRXSTAT"
+          fields:
+            - name: rxpktcnt
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Startevtclkn:
+          description: "STARTEVTCLKN"
+          fields:
+            - name: startevtclknts
+              bit_offset: 0
+              bit_size: 28
+
+        fieldset/bt_mac::regs::Startevtfinecnt:
+          description: "STARTEVTFINECNT"
+          fields:
+            - name: startevtfinecntts
+              bit_offset: 0
+              bit_size: 10
+
+        fieldset/bt_mac::regs::Endevtclkn:
+          description: "ENDEVTCLKN"
+          fields:
+            - name: endevtclknts
+              bit_offset: 0
+              bit_size: 28
+
+        fieldset/bt_mac::regs::Endevtfinecnt:
+          description: "ENDEVTFINECNT"
+          fields:
+            - name: endevtfinecntts
+              bit_offset: 0
+              bit_size: 10
+
+        fieldset/bt_mac::regs::Skipevtclkn:
+          description: "SKIPEVTCLKN"
+          fields:
+            - name: skipevtclknts
+              bit_offset: 0
+              bit_size: 28
+
+        fieldset/bt_mac::regs::Skipevtfinecnt:
+          description: "SKIPEVTFINECNT"
+          fields:
+            - name: skipevtfinecntts
+              bit_offset: 0
+              bit_size: 10
+
+        fieldset/bt_mac::regs::Advtim:
+          description: "ADVTIM"
+          fields:
+            - name: advint
+              bit_offset: 0
+              bit_size: 14
+            - name: rx_auxptr_thr
+              bit_offset: 16
+              bit_size: 8
+            - name: tx_auxptr_thr
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Actscancntl:
+          description: "ACTSCANCNTL"
+          fields:
+            - name: upperlimit
+              bit_offset: 0
+              bit_size: 9
+            - name: backoff
+              bit_offset: 16
+              bit_size: 9
+
+        fieldset/bt_mac::regs::Wpalcntl:
+          description: "WPALCNTL"
+          fields:
+            - name: wpalbaseptr
+              bit_offset: 0
+              bit_size: 14
+            - name: wpalnbdev
+              bit_offset: 16
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Wpalcurrent:
+          description: "WPALCURRENT"
+          fields:
+            - name: wpalcurrentptr
+              bit_offset: 0
+              bit_size: 16
+
+        fieldset/bt_mac::regs::SearchTimeout:
+          description: "SEARCH_TIMEOUT"
+          fields:
+            - name: search_timeout
+              bit_offset: 0
+              bit_size: 6
+
+        fieldset/bt_mac::regs::Blecoexifcntl0:
+          description: "BLECOEXIFCNTL0"
+          fields:
+            - name: wlancoex_en
+              bit_offset: 0
+              bit_size: 1
+            - name: syncgen_en
+              bit_offset: 1
+              bit_size: 1
+            - name: mwscoex_en
+              bit_offset: 2
+              bit_size: 1
+            - name: mwswci_en
+              bit_offset: 3
+              bit_size: 1
+            - name: wlanrxmsk
+              bit_offset: 4
+              bit_size: 2
+            - name: wlantxmsk
+              bit_offset: 6
+              bit_size: 2
+            - name: mwsrxmsk
+              bit_offset: 8
+              bit_size: 2
+            - name: mwstxmsk
+              bit_offset: 10
+              bit_size: 2
+            - name: mwsrxfreqmsk
+              bit_offset: 12
+              bit_size: 2
+            - name: mwstxfreqmsk
+              bit_offset: 14
+              bit_size: 2
+            - name: wlctxpriomode
+              bit_offset: 16
+              bit_size: 2
+            - name: wlcrxpriomode
+              bit_offset: 18
+              bit_size: 2
+            - name: mwsscanfreqmsk
+              bit_offset: 20
+              bit_size: 2
+
+        fieldset/bt_mac::regs::Blecoexifcntl1:
+          description: "BLECOEXIFCNTL1"
+          fields:
+            - name: wlcpdelay
+              bit_offset: 0
+              bit_size: 7
+            - name: wlcpduration
+              bit_offset: 8
+              bit_size: 7
+            - name: wlcptxthr
+              bit_offset: 16
+              bit_size: 5
+            - name: wlcprxthr
+              bit_offset: 24
+              bit_size: 5
+
+        fieldset/bt_mac::regs::Blecoexifcntl2:
+          description: "BLECOEXIFCNTL2"
+          fields:
+            - name: tx_ant_delay
+              bit_offset: 0
+              bit_size: 4
+            - name: rx_ant_delay
+              bit_offset: 8
+              bit_size: 4
+
+        fieldset/bt_mac::regs::Blemprio0:
+          description: "BLEMPRIO0"
+          fields:
+            - name: blem0
+              bit_offset: 0
+              bit_size: 4
+            - name: blem1
+              bit_offset: 4
+              bit_size: 4
+            - name: blem2
+              bit_offset: 8
+              bit_size: 4
+            - name: blem3
+              bit_offset: 12
+              bit_size: 4
+            - name: blem4
+              bit_offset: 16
+              bit_size: 4
+            - name: blem5
+              bit_offset: 20
+              bit_size: 4
+            - name: blem6
+              bit_offset: 24
+              bit_size: 4
+            - name: blem7
+              bit_offset: 28
+              bit_size: 4
+
+        fieldset/bt_mac::regs::Blemprio1:
+          description: "BLEMPRIO1"
+          fields:
+            - name: blem8
+              bit_offset: 0
+              bit_size: 4
+            - name: blem9
+              bit_offset: 4
+              bit_size: 4
+            - name: blem10
+              bit_offset: 8
+              bit_size: 4
+            - name: blem11
+              bit_offset: 12
+              bit_size: 4
+            - name: blem12
+              bit_offset: 16
+              bit_size: 4
+            - name: blem13
+              bit_offset: 20
+              bit_size: 4
+            - name: blem14
+              bit_offset: 24
+              bit_size: 4
+            - name: blem15
+              bit_offset: 28
+              bit_size: 4
+
+        fieldset/bt_mac::regs::Blemprio2:
+          description: "BLEMPRIO2"
+          fields:
+            - name: blem16
+              bit_offset: 0
+              bit_size: 4
+            - name: blem17
+              bit_offset: 4
+              bit_size: 4
+            - name: blem18
+              bit_offset: 8
+              bit_size: 4
+            - name: blemdefault
+              bit_offset: 28
+              bit_size: 4
+
+        fieldset/bt_mac::regs::Ralcntl:
+          description: "RALCNTL"
+          fields:
+            - name: ralbaseptr
+              bit_offset: 0
+              bit_size: 16
+            - name: ralnbdev
+              bit_offset: 16
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Ralcurrent:
+          description: "RALCURRENT"
+          fields:
+            - name: ralcurrentptr
+              bit_offset: 0
+              bit_size: 16
+
+        fieldset/bt_mac::regs::RalLocalRnd:
+          description: "RAL_LOCAL_RND"
+          fields:
+            - name: lrnd_val
+              bit_offset: 0
+              bit_size: 22
+            - name: lrnd_init
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::RalPeerRnd:
+          description: "RAL_PEER_RND"
+          fields:
+            - name: prnd_val
+              bit_offset: 0
+              bit_size: 22
+            - name: prnd_init
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Dfcntl01us:
+          description: "DFCNTL0_1US"
+          fields:
+            - name: txswstinst0_1us
+              bit_offset: 0
+              bit_size: 8
+            - name: rxswstinst0_1us
+              bit_offset: 16
+              bit_size: 8
+            - name: rxsampstinst0_1us
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Dfcntl02us:
+          description: "DFCNTL0_2US"
+          fields:
+            - name: txswstinst0_2us
+              bit_offset: 0
+              bit_size: 8
+            - name: rxswstinst0_2us
+              bit_offset: 16
+              bit_size: 8
+            - name: rxsampstinst0_2us
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Dfcntl11us:
+          description: "DFCNTL1_1US"
+          fields:
+            - name: txswstinst1_1us
+              bit_offset: 0
+              bit_size: 8
+            - name: rxswstinst1_1us
+              bit_offset: 16
+              bit_size: 8
+            - name: rxsampstinst1_1us
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Dfcntl12us:
+          description: "DFCNTL1_2US"
+          fields:
+            - name: txswstinst1_2us
+              bit_offset: 0
+              bit_size: 8
+            - name: rxswstinst1_2us
+              bit_offset: 16
+              bit_size: 8
+            - name: rxsampstinst1_2us
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Dfcurrentptr:
+          description: "DFCURRENTPTR"
+          fields:
+            - name: dfcurrentptr
+              bit_offset: 0
+              bit_size: 14
+
+        fieldset/bt_mac::regs::Dfantcntl:
+          description: "DFANTCNTL"
+          fields:
+            - name: txprimantid
+              bit_offset: 0
+              bit_size: 7
+            - name: txprimidcnten
+              bit_offset: 7
+              bit_size: 1
+            - name: rxprimantid
+              bit_offset: 8
+              bit_size: 7
+            - name: rxprimidcnten
+              bit_offset: 15
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Dfifcntl:
+          description: "DFIFCNTL"
+          fields:
+            - name: symbol_order
+              bit_offset: 0
+              bit_size: 1
+            - name: msb_lsb_order
+              bit_offset: 1
+              bit_size: 1
+            - name: if_width
+              bit_offset: 2
+              bit_size: 2
+            - name: sampvalid_beh
+              bit_offset: 4
+              bit_size: 2
+            - name: sampreq_beh
+              bit_offset: 6
+              bit_size: 1
+            - name: antswtcnt_beh
+              bit_offset: 7
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Freqselcntl:
+          description: "FREQSELCNTL"
+          fields:
+            - name: freqsel_start
+              bit_offset: 0
+              bit_size: 1
+            - name: freqsel_mode
+              bit_offset: 1
+              bit_size: 1
+            - name: nbloops
+              bit_offset: 16
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Freqselptr:
+          description: "FREQSELPTR"
+          fields:
+            - name: freqselptr
+              bit_offset: 0
+              bit_size: 14
+
+        fieldset/bt_mac::regs::FreqselCs1Seed:
+          description: "FREQSEL_CS1_SEED"
+          fields:
+            - name: freqsel_hopint
+              bit_offset: 0
+              bit_size: 5
+            - name: freqsel_last_chidx
+              bit_offset: 16
+              bit_size: 6
+
+        fieldset/bt_mac::regs::FreqCs2Seed:
+          description: "FREQ_CS2_SEED"
+          fields:
+            - name: freqsel_evtcnt
+              bit_offset: 0
+              bit_size: 16
+            - name: channel_identifier
+              bit_offset: 16
+              bit_size: 16
+
+        fieldset/bt_mac::regs::FreqselLlchmap0:
+          description: "FREQSEL_LLCHMAP0"
+          fields:
+            - name: freqsel_llchamp0
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::FreqselLlchmap1:
+          description: "FREQSEL_LLCHMAP1"
+          fields:
+            - name: freqsel_llchmap1
+              bit_offset: 0
+              bit_size: 5
+
+        fieldset/bt_mac::regs::Isocntcntl:
+          description: "ISOCNTCNTL"
+          fields:
+            - name: isocorrmode
+              bit_offset: 0
+              bit_size: 1
+            - name: iso_phase_shift_mode
+              bit_offset: 1
+              bit_size: 1
+            - name: iso_clkshift_mode
+              bit_offset: 2
+              bit_size: 1
+            - name: iso_upd
+              bit_offset: 30
+              bit_size: 1
+            - name: isosamp
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Isocntsamp:
+          description: "ISOCNTSAMP"
+          fields:
+            - name: isocntsamp
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Isocntcorr:
+          description: "ISOCNTCORR"
+          fields:
+            - name: isocntcorr
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::IsointcorrHus:
+          description: "ISOINTCORR_HUS"
+          fields:
+            - name: isocntcorr_hus
+              bit_offset: 0
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Isointcntl:
+          description: "ISOINTCNTL"
+          fields:
+            - name: isointmsk
+              bit_offset: 0
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Isointstat:
+          description: "ISOINTSTAT"
+          fields:
+            - name: isointstat
+              bit_offset: 0
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Isointack:
+          description: "ISOINTACK"
+          fields:
+            - name: isointack
+              bit_offset: 0
+              bit_size: 8
+
+        fieldset/bt_mac::regs::Isogpiocntl:
+          description: "ISOGPIOCNTL"
+          fields:
+            - name: isogpiomsk
+              bit_offset: 0
+              bit_size: 8
+            - name: isocpiobeh
+              bit_offset: 31
+              bit_size: 1
+
+        fieldset/bt_mac::regs::Isotimertgt0:
+          description: "ISOTIMERTGT0"
+          fields:
+            - name: isotimertgt0
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Isotimertgt1:
+          description: "ISOTIMERTGT1"
+          fields:
+            - name: isotimertgt1
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Isotimertgt2:
+          description: "ISOTIMERTGT2"
+          fields:
+            - name: isotimertgt2
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Isotimertgt3:
+          description: "ISOTIMERTGT3"
+          fields:
+            - name: isotimertgt3
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Isotimertgt4:
+          description: "ISOTIMERTGT4"
+          fields:
+            - name: isotimertgt4
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Isotimertgt5:
+          description: "ISOTIMERTGT5"
+          fields:
+            - name: isotimertgt5
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Isotimertgt6:
+          description: "ISOTIMERTGT6"
+          fields:
+            - name: isotimertgt6
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_mac::regs::Isotimertgt7:
+          description: "ISOTIMERTGT7"
+          fields:
+            - name: isotimertgt7
+              bit_offset: 0
+              bit_size: 32

--- a/transform/common/bt_mac.yaml
+++ b/transform/common/bt_mac.yaml
@@ -1,3 +1,13 @@
+# BT_MAC Peripheral Definition
+#
+# WARNING: This file contains register definitions derived from reverse-engineering
+# the SiFli C SDK. These are NOT official SVD definitions from the vendor.
+#
+# Source: SiFli-SDK headers and register maps
+# The vendor has declined to include Bluetooth-related registers in the official SVD.
+#
+# Use at your own risk. Register layouts may be incomplete or inaccurate.
+
 transforms:
 
   - !AddPeripherals

--- a/transform/common/bt_phy.yaml
+++ b/transform/common/bt_phy.yaml
@@ -1,3 +1,13 @@
+# BT_PHY Peripheral Definition
+#
+# WARNING: This file contains register definitions derived from reverse-engineering
+# the SiFli C SDK. These are NOT official SVD definitions from the vendor.
+#
+# Source: SiFli-SDK headers and register maps
+# The vendor has declined to include Bluetooth-related registers in the official SVD.
+#
+# Use at your own risk. Register layouts may be incomplete or inaccurate.
+
 transforms:
 
   - !AddPeripherals

--- a/transform/common/bt_phy.yaml
+++ b/transform/common/bt_phy.yaml
@@ -1,0 +1,1791 @@
+transforms:
+
+  - !AddPeripherals
+      devices: .*
+      peripherals:
+        - name: BT_PHY
+          base_address: 0x40084000
+          block: bt_phy::BtPhy
+
+  - !Add
+      ir:
+        block/bt_phy::BtPhy:
+          items:
+            - name: rx_ctrl1
+              byte_offset: 0x0
+              fieldset: bt_phy::regs::RxCtrl1
+            - name: rx_ctrl2
+              byte_offset: 0x4
+              fieldset: bt_phy::regs::RxCtrl2
+            - name: notch_cfg1
+              byte_offset: 0x8
+              fieldset: bt_phy::regs::NotchCfg1
+            - name: notch_cfg2
+              byte_offset: 0xc
+              fieldset: bt_phy::regs::NotchCfg2
+            - name: notch_cfg3
+              byte_offset: 0x10
+              fieldset: bt_phy::regs::NotchCfg3
+            - name: notch_cfg4
+              byte_offset: 0x14
+              fieldset: bt_phy::regs::NotchCfg4
+            - name: notch_cfg5
+              byte_offset: 0x18
+              fieldset: bt_phy::regs::NotchCfg5
+            - name: notch_cfg6
+              byte_offset: 0x1c
+              fieldset: bt_phy::regs::NotchCfg6
+            - name: notch_cfg7
+              byte_offset: 0x20
+              fieldset: bt_phy::regs::NotchCfg7
+            - name: notch_cfg8
+              byte_offset: 0x24
+              fieldset: bt_phy::regs::NotchCfg8
+            - name: notch_cfg9
+              byte_offset: 0x28
+              fieldset: bt_phy::regs::NotchCfg9
+            - name: notch_cfg10
+              byte_offset: 0x2c
+              fieldset: bt_phy::regs::NotchCfg10
+            - name: notch_cfg11
+              byte_offset: 0x30
+              fieldset: bt_phy::regs::NotchCfg11
+            - name: notch_cfg12
+              byte_offset: 0x34
+              fieldset: bt_phy::regs::NotchCfg12
+            - name: notch_cfg13
+              byte_offset: 0x38
+              fieldset: bt_phy::regs::NotchCfg13
+            - name: notch_cfg14
+              byte_offset: 0x3c
+              fieldset: bt_phy::regs::NotchCfg14
+            - name: interp_cfg1
+              byte_offset: 0x40
+              fieldset: bt_phy::regs::InterpCfg1
+            - name: ted_cfg1
+              byte_offset: 0x44
+              fieldset: bt_phy::regs::TedCfg1
+            - name: mixer_cfg1
+              byte_offset: 0x48
+              fieldset: bt_phy::regs::MixerCfg1
+            - name: pktdet_cfg1
+              byte_offset: 0x4c
+              fieldset: bt_phy::regs::PktdetCfg1
+            - name: pktdet_cfg2
+              byte_offset: 0x50
+              fieldset: bt_phy::regs::PktdetCfg2
+            - name: demod_cfg1
+              byte_offset: 0x54
+              fieldset: bt_phy::regs::DemodCfg1
+            - name: demod_cfg2
+              byte_offset: 0x58
+              fieldset: bt_phy::regs::DemodCfg2
+            - name: demod_cfg3
+              byte_offset: 0x5c
+              fieldset: bt_phy::regs::DemodCfg3
+            - name: demod_cfg4
+              byte_offset: 0x60
+              fieldset: bt_phy::regs::DemodCfg4
+            - name: demod_cfg5
+              byte_offset: 0x64
+              fieldset: bt_phy::regs::DemodCfg5
+            - name: demod_cfg6
+              byte_offset: 0x68
+              fieldset: bt_phy::regs::DemodCfg6
+            - name: demod_cfg7
+              byte_offset: 0x6c
+              fieldset: bt_phy::regs::DemodCfg7
+            - name: demod_cfg8
+              byte_offset: 0x70
+              fieldset: bt_phy::regs::DemodCfg8
+            - name: demod_cfg9
+              byte_offset: 0x74
+              fieldset: bt_phy::regs::DemodCfg9
+            - name: demod_cfg10
+              byte_offset: 0x78
+              fieldset: bt_phy::regs::DemodCfg10
+            - name: demod_cfg11
+              byte_offset: 0x7c
+              fieldset: bt_phy::regs::DemodCfg11
+            - name: demod_cfg12
+              byte_offset: 0x80
+              fieldset: bt_phy::regs::DemodCfg12
+            - name: demod_cfg13
+              byte_offset: 0x84
+              fieldset: bt_phy::regs::DemodCfg13
+            - name: demod_cfg14
+              byte_offset: 0x88
+              fieldset: bt_phy::regs::DemodCfg14
+            - name: demod_cfg15
+              byte_offset: 0x8c
+              fieldset: bt_phy::regs::DemodCfg15
+            - name: demod_cfg16
+              byte_offset: 0x90
+              fieldset: bt_phy::regs::DemodCfg16
+            - name: demod_cfg17
+              byte_offset: 0x94
+              fieldset: bt_phy::regs::DemodCfg17
+            - name: rx_status1
+              byte_offset: 0x98
+              fieldset: bt_phy::regs::RxStatus1
+            - name: agc_ctrl
+              byte_offset: 0x9c
+              fieldset: bt_phy::regs::AgcCtrl
+            - name: agc_cfg1
+              byte_offset: 0xa0
+              fieldset: bt_phy::regs::AgcCfg1
+            - name: agc_cfg2
+              byte_offset: 0xa4
+              fieldset: bt_phy::regs::AgcCfg2
+            - name: agc_cfg3
+              byte_offset: 0xa8
+              fieldset: bt_phy::regs::AgcCfg3
+            - name: agc_cfg4
+              byte_offset: 0xac
+              fieldset: bt_phy::regs::AgcCfg4
+            - name: agc_cfg5
+              byte_offset: 0xb0
+              fieldset: bt_phy::regs::AgcCfg5
+            - name: agc_cfg6
+              byte_offset: 0xb4
+              fieldset: bt_phy::regs::AgcCfg6
+            - name: agc_cfg7
+              byte_offset: 0xb8
+              fieldset: bt_phy::regs::AgcCfg7
+            - name: agc_cfg8
+              byte_offset: 0xbc
+              fieldset: bt_phy::regs::AgcCfg8
+            - name: agc_cfg9
+              byte_offset: 0xc0
+              fieldset: bt_phy::regs::AgcCfg9
+            - name: agc_cfg10
+              byte_offset: 0xc4
+              fieldset: bt_phy::regs::AgcCfg10
+            - name: agc_cfg11
+              byte_offset: 0xc8
+              fieldset: bt_phy::regs::AgcCfg11
+            - name: agc_cfg12
+              byte_offset: 0xcc
+              fieldset: bt_phy::regs::AgcCfg12
+            - name: rssi_cfg1
+              byte_offset: 0xd0
+              fieldset: bt_phy::regs::RssiCfg1
+            - name: agc_status
+              byte_offset: 0xd4
+              fieldset: bt_phy::regs::AgcStatus
+            - name: edrsync_cfg1
+              byte_offset: 0xd8
+              fieldset: bt_phy::regs::EdrsyncCfg1
+            - name: edrsync_cfg2
+              byte_offset: 0xdc
+              fieldset: bt_phy::regs::EdrsyncCfg2
+            - name: edrdemod_cfg1
+              byte_offset: 0xe0
+              fieldset: bt_phy::regs::EdrdemodCfg1
+            - name: edrdemod_cfg2
+              byte_offset: 0xe4
+              fieldset: bt_phy::regs::EdrdemodCfg2
+            - name: edrted_cfg1
+              byte_offset: 0xe8
+              fieldset: bt_phy::regs::EdrtedCfg1
+            - name: tx_ctrl
+              byte_offset: 0xec
+              fieldset: bt_phy::regs::TxCtrl
+            - name: tx_rcc_ctrl
+              byte_offset: 0xf0
+              fieldset: bt_phy::regs::TxRccCtrl
+            - name: tx_gaussflt_cfg1
+              byte_offset: 0xf4
+              fieldset: bt_phy::regs::TxGaussfltCfg1
+            - name: tx_gaussflt_cfg2
+              byte_offset: 0xf8
+              fieldset: bt_phy::regs::TxGaussfltCfg2
+            - name: tx_if_mod_cfg
+              byte_offset: 0xfc
+              fieldset: bt_phy::regs::TxIfModCfg
+            - name: tx_if_mod_cfg2
+              byte_offset: 0x100
+              fieldset: bt_phy::regs::TxIfModCfg2
+            - name: tx_if_mod_cfg3
+              byte_offset: 0x104
+              fieldset: bt_phy::regs::TxIfModCfg3
+            - name: tx_if_mod_cfg4
+              byte_offset: 0x108
+              fieldset: bt_phy::regs::TxIfModCfg4
+            - name: tx_if_mod_cfg5
+              byte_offset: 0x10c
+              fieldset: bt_phy::regs::TxIfModCfg5
+            - name: tx_if_mod_cfg6
+              byte_offset: 0x110
+              fieldset: bt_phy::regs::TxIfModCfg6
+            - name: tx_if_mod_cfg7
+              byte_offset: 0x114
+              fieldset: bt_phy::regs::TxIfModCfg7
+            - name: tx_hfp_cfg
+              byte_offset: 0x118
+              fieldset: bt_phy::regs::TxHfpCfg
+            - name: tx_lfp_cfg
+              byte_offset: 0x11c
+              fieldset: bt_phy::regs::TxLfpCfg
+            - name: tx_pa_cfg
+              byte_offset: 0x120
+              fieldset: bt_phy::regs::TxPaCfg
+            - name: tx_dpsk_cfg1
+              byte_offset: 0x124
+              fieldset: bt_phy::regs::TxDpskCfg1
+            - name: tx_dpsk_cfg2
+              byte_offset: 0x128
+              fieldset: bt_phy::regs::TxDpskCfg2
+            - name: tx_dc_cal_cfg0
+              byte_offset: 0x12c
+              fieldset: bt_phy::regs::TxDcCalCfg0
+            - name: tx_dc_cal_cfg1
+              byte_offset: 0x130
+              fieldset: bt_phy::regs::TxDcCalCfg1
+            - name: tx_dc_cal_cfg2
+              byte_offset: 0x134
+              fieldset: bt_phy::regs::TxDcCalCfg2
+            - name: lfp_mmdiv_cfg0
+              byte_offset: 0x138
+              fieldset: bt_phy::regs::LfpMmdivCfg0
+            - name: lfp_mmdiv_cfg1
+              byte_offset: 0x13c
+              fieldset: bt_phy::regs::LfpMmdivCfg1
+            - name: lfp_mmdiv_cfg2
+              byte_offset: 0x140
+              fieldset: bt_phy::regs::LfpMmdivCfg2
+            - name: lfp_mmdiv_cfg3
+              byte_offset: 0x144
+              fieldset: bt_phy::regs::LfpMmdivCfg3
+            - name: lfp_mmdiv_cfg4
+              byte_offset: 0x148
+              fieldset: bt_phy::regs::LfpMmdivCfg4
+            - name: rx_hfp_cfg
+              byte_offset: 0x14c
+              fieldset: bt_phy::regs::RxHfpCfg
+            - name: lna_gain_tbl0
+              byte_offset: 0x150
+              fieldset: bt_phy::regs::LnaGainTbl0
+            - name: lna_gain_tbl1
+              byte_offset: 0x154
+              fieldset: bt_phy::regs::LnaGainTbl1
+            - name: lna_gain_tbl2
+              byte_offset: 0x158
+              fieldset: bt_phy::regs::LnaGainTbl2
+            - name: lna_gain_tbl3
+              byte_offset: 0x15c
+              fieldset: bt_phy::regs::LnaGainTbl3
+            - name: lna_gain_tbl4
+              byte_offset: 0x160
+              fieldset: bt_phy::regs::LnaGainTbl4
+            - name: lna_gain_tbl5
+              byte_offset: 0x164
+              fieldset: bt_phy::regs::LnaGainTbl5
+            - name: rcos_cfg0
+              byte_offset: 0x168
+              fieldset: bt_phy::regs::RcosCfg0
+            - name: rcos_cfg1
+              byte_offset: 0x16c
+              fieldset: bt_phy::regs::RcosCfg1
+            - name: rcos_cfg2
+              byte_offset: 0x170
+              fieldset: bt_phy::regs::RcosCfg2
+            - name: rcos_cfg3
+              byte_offset: 0x174
+              fieldset: bt_phy::regs::RcosCfg3
+            - name: rcos_cfg4
+              byte_offset: 0x178
+              fieldset: bt_phy::regs::RcosCfg4
+            - name: rcos_cfg5
+              byte_offset: 0x17c
+              fieldset: bt_phy::regs::RcosCfg5
+            - name: rcos_cfg6
+              byte_offset: 0x180
+              fieldset: bt_phy::regs::RcosCfg6
+            - name: rcos_cfg7
+              byte_offset: 0x184
+              fieldset: bt_phy::regs::RcosCfg7
+            - name: rcos_cfg8
+              byte_offset: 0x188
+              fieldset: bt_phy::regs::RcosCfg8
+            - name: rcos_cfg9
+              byte_offset: 0x18c
+              fieldset: bt_phy::regs::RcosCfg9
+            - name: rcos_cfg10
+              byte_offset: 0x190
+              fieldset: bt_phy::regs::RcosCfg10
+            - name: rcos_cfg11
+              byte_offset: 0x194
+              fieldset: bt_phy::regs::RcosCfg11
+            - name: rcos_cfg12
+              byte_offset: 0x198
+              fieldset: bt_phy::regs::RcosCfg12
+            - name: rcos_cfg13
+              byte_offset: 0x19c
+              fieldset: bt_phy::regs::RcosCfg13
+            - name: rcos_cfg14
+              byte_offset: 0x1a0
+              fieldset: bt_phy::regs::RcosCfg14
+            - name: rcos_cfg15
+              byte_offset: 0x1a4
+              fieldset: bt_phy::regs::RcosCfg15
+            - name: rcos_cfg16
+              byte_offset: 0x1a8
+              fieldset: bt_phy::regs::RcosCfg16
+            - name: rcos_cfg17
+              byte_offset: 0x1ac
+              fieldset: bt_phy::regs::RcosCfg17
+            - name: rcos_cfg18
+              byte_offset: 0x1b0
+              fieldset: bt_phy::regs::RcosCfg18
+            - name: lpf_cfg0
+              byte_offset: 0x1b4
+              fieldset: bt_phy::regs::LpfCfg0
+            - name: lpf_cfg1
+              byte_offset: 0x1b8
+              fieldset: bt_phy::regs::LpfCfg1
+            - name: lpf_cfg2
+              byte_offset: 0x1bc
+              fieldset: bt_phy::regs::LpfCfg2
+            - name: lpf_cfg3
+              byte_offset: 0x1c0
+              fieldset: bt_phy::regs::LpfCfg3
+
+        fieldset/bt_phy::regs::RxCtrl1:
+          description: "RX_CTRL1"
+          fields:
+            - name: adc_sign
+              bit_offset: 0
+              bit_size: 1
+            - name: mixer_iq_swap_en
+              bit_offset: 1
+              bit_size: 1
+            - name: adc_iq_swap_en
+              bit_offset: 2
+              bit_size: 1
+            - name: force_rx_on
+              bit_offset: 3
+              bit_size: 1
+            - name: adc_q_en_1
+              bit_offset: 4
+              bit_size: 1
+            - name: lpf1_sample_phase_sel
+              bit_offset: 5
+              bit_size: 1
+            - name: rssi_sample_sel
+              bit_offset: 6
+              bit_size: 1
+            - name: phy_rx_dump_en
+              bit_offset: 7
+              bit_size: 1
+            - name: rx_dump_clk_sel
+              bit_offset: 8
+              bit_size: 2
+            - name: rx_dump_data_sel
+              bit_offset: 10
+              bit_size: 5
+            - name: rx_dbg_trig_sel
+              bit_offset: 15
+              bit_size: 2
+            - name: rx_dbg_data_sel
+              bit_offset: 17
+              bit_size: 5
+            - name: rx_loopback_mode
+              bit_offset: 22
+              bit_size: 1
+            - name: rx_dump_q_sel
+              bit_offset: 23
+              bit_size: 1
+            - name: frc_adc_24m
+              bit_offset: 24
+              bit_size: 1
+            - name: edr_notch_off_en
+              bit_offset: 25
+              bit_size: 1
+            - name: bt_op_mode
+              bit_offset: 26
+              bit_size: 1
+
+        fieldset/bt_phy::regs::RxCtrl2:
+          description: "RX_CTRL2"
+          fields:
+            - name: force_clk_on_agc
+              bit_offset: 0
+              bit_size: 1
+            - name: force_rx_reset
+              bit_offset: 1
+              bit_size: 1
+            - name: cbpf_edr_switch_t0
+              bit_offset: 2
+              bit_size: 5
+            - name: cbpf_edr_switch_t1
+              bit_offset: 7
+              bit_size: 5
+            - name: adc_edr_switch_t0
+              bit_offset: 12
+              bit_size: 5
+            - name: adc_edr_switch_t1
+              bit_offset: 17
+              bit_size: 5
+            - name: adc_q_en_2
+              bit_offset: 22
+              bit_size: 1
+            - name: adc_q_en_c
+              bit_offset: 23
+              bit_size: 1
+            - name: adc_q_en_br
+              bit_offset: 24
+              bit_size: 1
+            - name: adc_q_en_edr
+              bit_offset: 25
+              bit_size: 1
+            - name: adc_q_en_frc_en
+              bit_offset: 26
+              bit_size: 1
+
+        fieldset/bt_phy::regs::NotchCfg1:
+          description: "NOTCH_CFG1"
+          fields:
+            - name: notch_b0_1
+              bit_offset: 0
+              bit_size: 14
+            - name: notch_b1_1
+              bit_offset: 14
+              bit_size: 14
+
+        fieldset/bt_phy::regs::NotchCfg2:
+          description: "NOTCH_CFG2"
+          fields:
+            - name: notch_a2_1
+              bit_offset: 0
+              bit_size: 14
+            - name: notch_a2_2
+              bit_offset: 14
+              bit_size: 14
+
+        fieldset/bt_phy::regs::NotchCfg3:
+          description: "NOTCH_CFG3"
+          fields:
+            - name: notch_b0_2
+              bit_offset: 0
+              bit_size: 14
+            - name: notch_b1_2
+              bit_offset: 14
+              bit_size: 14
+
+        fieldset/bt_phy::regs::NotchCfg4:
+          description: "NOTCH_CFG4"
+          fields:
+            - name: notch_b0_b
+              bit_offset: 0
+              bit_size: 14
+            - name: notch_b1_b
+              bit_offset: 14
+              bit_size: 14
+
+        fieldset/bt_phy::regs::NotchCfg5:
+          description: "NOTCH_CFG5"
+          fields:
+            - name: notch_a2_b
+              bit_offset: 0
+              bit_size: 14
+
+        fieldset/bt_phy::regs::NotchCfg6:
+          description: "NOTCH_CFG6"
+          fields:
+            - name: chnl_notch_en0_1
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_phy::regs::NotchCfg7:
+          description: "NOTCH_CFG7"
+          fields:
+            - name: chnl_notch_en1_1
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_phy::regs::NotchCfg8:
+          description: "NOTCH_CFG8"
+          fields:
+            - name: chnl_notch_en2_1
+              bit_offset: 0
+              bit_size: 15
+            - name: notch_rssi_thd_1
+              bit_offset: 15
+              bit_size: 8
+
+        fieldset/bt_phy::regs::NotchCfg9:
+          description: "NOTCH_CFG9"
+          fields:
+            - name: chnl_notch_en0_2
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_phy::regs::NotchCfg10:
+          description: "NOTCH_CFG10"
+          fields:
+            - name: chnl_notch_en1_2
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_phy::regs::NotchCfg11:
+          description: "NOTCH_CFG11"
+          fields:
+            - name: chnl_notch_en2_2
+              bit_offset: 0
+              bit_size: 15
+            - name: notch_rssi_thd_2
+              bit_offset: 15
+              bit_size: 8
+
+        fieldset/bt_phy::regs::NotchCfg12:
+          description: "NOTCH_CFG12"
+          fields:
+            - name: chnl_notch_en0_b
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_phy::regs::NotchCfg13:
+          description: "NOTCH_CFG13"
+          fields:
+            - name: chnl_notch_en1_b
+              bit_offset: 0
+              bit_size: 32
+
+        fieldset/bt_phy::regs::NotchCfg14:
+          description: "NOTCH_CFG14"
+          fields:
+            - name: chnl_notch_en2_b
+              bit_offset: 0
+              bit_size: 15
+            - name: notch_rssi_thd_b
+              bit_offset: 15
+              bit_size: 8
+
+        fieldset/bt_phy::regs::InterpCfg1:
+          description: "INTERP_CFG1"
+          fields:
+            - name: timing_factor
+              bit_offset: 0
+              bit_size: 7
+            - name: interp_method_u
+              bit_offset: 7
+              bit_size: 1
+            - name: interp_en_u
+              bit_offset: 8
+              bit_size: 1
+            - name: interp_method_b
+              bit_offset: 9
+              bit_size: 1
+            - name: interp_en_b
+              bit_offset: 10
+              bit_size: 1
+
+        fieldset/bt_phy::regs::TedCfg1:
+          description: "TED_CFG1"
+          fields:
+            - name: ted_mu_p_u
+              bit_offset: 0
+              bit_size: 4
+            - name: ted_mu_f_u
+              bit_offset: 4
+              bit_size: 4
+            - name: ted_mu_p_br
+              bit_offset: 8
+              bit_size: 4
+            - name: ted_mu_f_br
+              bit_offset: 12
+              bit_size: 4
+
+        fieldset/bt_phy::regs::MixerCfg1:
+          description: "MIXER_CFG1"
+          fields:
+            - name: rx_mixer_phase_1
+              bit_offset: 0
+              bit_size: 10
+            - name: rx_mixer_phase_2
+              bit_offset: 10
+              bit_size: 10
+            - name: rx_mixer_phase_bt
+              bit_offset: 20
+              bit_size: 10
+
+        fieldset/bt_phy::regs::PktdetCfg1:
+          description: "PKTDET_CFG1"
+          fields:
+            - name: ble_pktdet_thd
+              bit_offset: 0
+              bit_size: 14
+            - name: ble_pkt_cnt_thd
+              bit_offset: 14
+              bit_size: 9
+            - name: ble_hard_corr_thd
+              bit_offset: 23
+              bit_size: 5
+
+        fieldset/bt_phy::regs::PktdetCfg2:
+          description: "PKTDET_CFG2"
+          fields:
+            - name: br_pktdet_thd
+              bit_offset: 0
+              bit_size: 14
+            - name: br_pkt_cnt_thd
+              bit_offset: 14
+              bit_size: 9
+            - name: br_hard_corr_thd
+              bit_offset: 23
+              bit_size: 5
+
+        fieldset/bt_phy::regs::DemodCfg1:
+          description: "DEMOD_CFG1"
+          fields:
+            - name: ble_mu_err
+              bit_offset: 0
+              bit_size: 10
+            - name: ble_mu_dc
+              bit_offset: 10
+              bit_size: 10
+            - name: ble_demod_g
+              bit_offset: 20
+              bit_size: 11
+
+        fieldset/bt_phy::regs::DemodCfg2:
+          description: "DEMOD_CFG2"
+          fields:
+            - name: ble_demod_phase_0
+              bit_offset: 0
+              bit_size: 12
+            - name: ble_demod_phase_1
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::DemodCfg3:
+          description: "DEMOD_CFG3"
+          fields:
+            - name: ble_demod_phase_2
+              bit_offset: 0
+              bit_size: 12
+            - name: ble_demod_phase_3
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::DemodCfg4:
+          description: "DEMOD_CFG4"
+          fields:
+            - name: ble_demod_phase_4
+              bit_offset: 0
+              bit_size: 12
+            - name: ble_demod_phase_5
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::DemodCfg5:
+          description: "DEMOD_CFG5"
+          fields:
+            - name: ble_demod_phase_6
+              bit_offset: 0
+              bit_size: 12
+            - name: ble_demod_phase_7
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::DemodCfg6:
+          description: "DEMOD_CFG6"
+          fields:
+            - name: ble_demod_phase_ideal_0
+              bit_offset: 0
+              bit_size: 12
+            - name: ble_demod_phase_ideal_1
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::DemodCfg7:
+          description: "DEMOD_CFG7"
+          fields:
+            - name: ble_demod_phase_ideal_2
+              bit_offset: 0
+              bit_size: 12
+            - name: ble_demod_phase_ideal_3
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::DemodCfg8:
+          description: "DEMOD_CFG8"
+          fields:
+            - name: br_mu_err
+              bit_offset: 0
+              bit_size: 10
+            - name: br_mu_dc
+              bit_offset: 10
+              bit_size: 10
+            - name: br_demod_g
+              bit_offset: 20
+              bit_size: 11
+
+        fieldset/bt_phy::regs::DemodCfg9:
+          description: "DEMOD_CFG9"
+          fields:
+            - name: br_demod_phase_0
+              bit_offset: 0
+              bit_size: 12
+            - name: br_demod_phase_1
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::DemodCfg10:
+          description: "DEMOD_CFG10"
+          fields:
+            - name: br_demod_phase_2
+              bit_offset: 0
+              bit_size: 12
+            - name: br_demod_phase_3
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::DemodCfg11:
+          description: "DEMOD_CFG11"
+          fields:
+            - name: br_demod_phase_4
+              bit_offset: 0
+              bit_size: 12
+            - name: br_demod_phase_5
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::DemodCfg12:
+          description: "DEMOD_CFG12"
+          fields:
+            - name: br_demod_phase_6
+              bit_offset: 0
+              bit_size: 12
+            - name: br_demod_phase_7
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::DemodCfg13:
+          description: "DEMOD_CFG13"
+          fields:
+            - name: br_demod_phase_ideal_0
+              bit_offset: 0
+              bit_size: 12
+            - name: br_demod_phase_ideal_1
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::DemodCfg14:
+          description: "DEMOD_CFG14"
+          fields:
+            - name: br_demod_phase_ideal_2
+              bit_offset: 0
+              bit_size: 12
+            - name: br_demod_phase_ideal_3
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::DemodCfg15:
+          description: "DEMOD_CFG15"
+          fields:
+            - name: ble_hadapt_en
+              bit_offset: 0
+              bit_size: 1
+            - name: ble_mu_h
+              bit_offset: 1
+              bit_size: 10
+            - name: ble_demod_h
+              bit_offset: 11
+              bit_size: 11
+
+        fieldset/bt_phy::regs::DemodCfg16:
+          description: "DEMOD_CFG16"
+          fields:
+            - name: br_hadapt_en
+              bit_offset: 0
+              bit_size: 1
+            - name: br_mu_h
+              bit_offset: 1
+              bit_size: 10
+            - name: br_demod_h
+              bit_offset: 11
+              bit_size: 11
+
+        fieldset/bt_phy::regs::DemodCfg17:
+          description: "DEMOD_CFG17"
+          fields:
+            - name: hadapt_l
+              bit_offset: 0
+              bit_size: 11
+            - name: hadapt_h
+              bit_offset: 11
+              bit_size: 11
+
+        fieldset/bt_phy::regs::RxStatus1:
+          description: "RX_STATUS1"
+          fields:
+            - name: cfo_phase
+              bit_offset: 0
+              bit_size: 12
+            - name: edr_carrier_phase
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::AgcCtrl:
+          description: "AGC_CTRL"
+          fields:
+            - name: agc_enable
+              bit_offset: 0
+              bit_size: 1
+            - name: agc_mode
+              bit_offset: 1
+              bit_size: 1
+            - name: dig_gain_en
+              bit_offset: 2
+              bit_size: 1
+            - name: agc_vgaadj_en
+              bit_offset: 3
+              bit_size: 1
+
+        fieldset/bt_phy::regs::AgcCfg1:
+          description: "AGC_CFG1"
+          fields:
+            - name: adc_mag_thd0
+              bit_offset: 0
+              bit_size: 10
+            - name: adc_mag_thd1
+              bit_offset: 10
+              bit_size: 10
+            - name: adc_mag_thd2
+              bit_offset: 20
+              bit_size: 10
+
+        fieldset/bt_phy::regs::AgcCfg2:
+          description: "AGC_CFG2"
+          fields:
+            - name: adc_mag_cnt_thd0
+              bit_offset: 0
+              bit_size: 4
+            - name: adc_mag_cnt_thd1
+              bit_offset: 4
+              bit_size: 4
+            - name: adc_mag_cnt_thd2
+              bit_offset: 8
+              bit_size: 4
+            - name: adc_mag_set
+              bit_offset: 12
+              bit_size: 10
+
+        fieldset/bt_phy::regs::AgcCfg3:
+          description: "AGC_CFG3"
+          fields:
+            - name: adc_sat_thd
+              bit_offset: 0
+              bit_size: 10
+            - name: adc_sat_num
+              bit_offset: 10
+              bit_size: 4
+            - name: adc_sat_thd_bt
+              bit_offset: 14
+              bit_size: 10
+            - name: adc_sat_num_bt
+              bit_offset: 24
+              bit_size: 4
+
+        fieldset/bt_phy::regs::AgcCfg4:
+          description: "AGC_CFG4"
+          fields:
+            - name: lna_mixer_gain_index_thd
+              bit_offset: 0
+              bit_size: 4
+            - name: cbpf_gain_index_thd
+              bit_offset: 4
+              bit_size: 2
+            - name: vga_gain_index_thd
+              bit_offset: 6
+              bit_size: 4
+            - name: lna_mixer_gain_index_init
+              bit_offset: 10
+              bit_size: 4
+            - name: cbpf_gain_index_init
+              bit_offset: 14
+              bit_size: 2
+            - name: vga_gain_index_init
+              bit_offset: 16
+              bit_size: 4
+            - name: lna_mixer_gain_index_step
+              bit_offset: 20
+              bit_size: 4
+            - name: cbpf_gain_index_step
+              bit_offset: 24
+              bit_size: 2
+            - name: vga_gain_index_step
+              bit_offset: 26
+              bit_size: 4
+
+        fieldset/bt_phy::regs::AgcCfg5:
+          description: "AGC_CFG5"
+          fields:
+            - name: agc_cbpf_gain_index_setting0
+              bit_offset: 0
+              bit_size: 2
+            - name: agc_vga_gain_index_setting0
+              bit_offset: 2
+              bit_size: 4
+            - name: dig_gain_low
+              bit_offset: 6
+              bit_size: 6
+            - name: dig_gain_high
+              bit_offset: 12
+              bit_size: 6
+            - name: adc_power_target_bt
+              bit_offset: 18
+              bit_size: 7
+
+        fieldset/bt_phy::regs::AgcCfg6:
+          description: "AGC_CFG6"
+          fields:
+            - name: agc_delay_reset_1
+              bit_offset: 0
+              bit_size: 7
+            - name: agc_delay_pkdet_1
+              bit_offset: 7
+              bit_size: 7
+            - name: agc_delay_lna_1
+              bit_offset: 14
+              bit_size: 7
+            - name: agc_delay_dig_1
+              bit_offset: 21
+              bit_size: 7
+
+        fieldset/bt_phy::regs::AgcCfg7:
+          description: "AGC_CFG7"
+          fields:
+            - name: agc_delay_reset_2
+              bit_offset: 0
+              bit_size: 7
+            - name: agc_delay_pkdet_2
+              bit_offset: 7
+              bit_size: 7
+            - name: agc_delay_lna_2
+              bit_offset: 14
+              bit_size: 7
+            - name: agc_delay_dig_2
+              bit_offset: 21
+              bit_size: 7
+
+        fieldset/bt_phy::regs::AgcCfg8:
+          description: "AGC_CFG8"
+          fields:
+            - name: agc_delay_cbpf_1
+              bit_offset: 0
+              bit_size: 7
+            - name: agc_delay_adc_1
+              bit_offset: 7
+              bit_size: 7
+            - name: dig_gain_window_1
+              bit_offset: 14
+              bit_size: 7
+            - name: adc_power_target
+              bit_offset: 21
+              bit_size: 7
+
+        fieldset/bt_phy::regs::AgcCfg9:
+          description: "AGC_CFG9"
+          fields:
+            - name: agc_delay_cbpf_2
+              bit_offset: 0
+              bit_size: 7
+            - name: agc_delay_adc_2
+              bit_offset: 7
+              bit_size: 7
+            - name: dig_gain_window_2
+              bit_offset: 14
+              bit_size: 7
+
+        fieldset/bt_phy::regs::AgcCfg10:
+          description: "AGC_CFG10"
+          fields:
+            - name: agc_peakdet_timer_set1_1
+              bit_offset: 0
+              bit_size: 7
+            - name: agc_peakdet_cnt_thd1_1
+              bit_offset: 7
+              bit_size: 7
+            - name: agc_peakdet_timer_set2_1
+              bit_offset: 14
+              bit_size: 7
+            - name: agc_peakdet_cnt_thd2_1
+              bit_offset: 21
+              bit_size: 7
+
+        fieldset/bt_phy::regs::AgcCfg11:
+          description: "AGC_CFG11"
+          fields:
+            - name: agc_peakdet_timer_set1_2
+              bit_offset: 0
+              bit_size: 7
+            - name: agc_peakdet_cnt_thd1_2
+              bit_offset: 7
+              bit_size: 7
+            - name: agc_peakdet_timer_set2_2
+              bit_offset: 14
+              bit_size: 7
+            - name: agc_peakdet_cnt_thd2_2
+              bit_offset: 21
+              bit_size: 7
+
+        fieldset/bt_phy::regs::AgcCfg12:
+          description: "AGC_CFG12"
+          fields:
+            - name: agc_urun_window_1
+              bit_offset: 0
+              bit_size: 7
+            - name: agc_urun_window_2
+              bit_offset: 7
+              bit_size: 7
+            - name: adc_power_urun_thd
+              bit_offset: 14
+              bit_size: 7
+
+        fieldset/bt_phy::regs::RssiCfg1:
+          description: "RSSI_CFG1"
+          fields:
+            - name: dig_gain_low_db
+              bit_offset: 0
+              bit_size: 7
+            - name: dig_gain_high_db
+              bit_offset: 7
+              bit_size: 7
+            - name: rssi_mu
+              bit_offset: 14
+              bit_size: 3
+            - name: rssi_offset
+              bit_offset: 17
+              bit_size: 6
+
+        fieldset/bt_phy::regs::AgcStatus:
+          description: "AGC_STATUS"
+          fields:
+            - name: lna_mixer_gain_index
+              bit_offset: 0
+              bit_size: 4
+            - name: cbpf_gain_index
+              bit_offset: 4
+              bit_size: 2
+            - name: vga_gain_index
+              bit_offset: 6
+              bit_size: 4
+            - name: adc_dig_gain
+              bit_offset: 10
+              bit_size: 6
+            - name: rssi
+              bit_offset: 16
+              bit_size: 8
+            - name: pkdet_ana
+              bit_offset: 24
+              bit_size: 6
+
+        fieldset/bt_phy::regs::EdrsyncCfg1:
+          description: "EDRSYNC_CFG1"
+          fields:
+            - name: edrsync_cnt_thd
+              bit_offset: 0
+              bit_size: 8
+            - name: edrsync_phasecorr_thd
+              bit_offset: 8
+              bit_size: 18
+            - name: edrsync_method
+              bit_offset: 26
+              bit_size: 1
+
+        fieldset/bt_phy::regs::EdrsyncCfg2:
+          description: "EDRSYNC_CFG2"
+          fields:
+            - name: edrsync_phaseunwrap_thd
+              bit_offset: 0
+              bit_size: 8
+
+        fieldset/bt_phy::regs::EdrdemodCfg1:
+          description: "EDRDEMOD_CFG1"
+          fields:
+            - name: edr2_mu_err
+              bit_offset: 0
+              bit_size: 10
+            - name: edr2_mu_dc
+              bit_offset: 10
+              bit_size: 10
+
+        fieldset/bt_phy::regs::EdrdemodCfg2:
+          description: "EDRDEMOD_CFG2"
+          fields:
+            - name: edr3_mu_err
+              bit_offset: 0
+              bit_size: 10
+            - name: edr3_mu_dc
+              bit_offset: 10
+              bit_size: 10
+
+        fieldset/bt_phy::regs::EdrtedCfg1:
+          description: "EDRTED_CFG1"
+          fields:
+            - name: ted_edr2_mu_p
+              bit_offset: 0
+              bit_size: 4
+            - name: ted_edr2_mu_f
+              bit_offset: 4
+              bit_size: 4
+            - name: ted_edr3_mu_p
+              bit_offset: 8
+              bit_size: 4
+            - name: ted_edr3_mu_f
+              bit_offset: 12
+              bit_size: 4
+
+        fieldset/bt_phy::regs::TxCtrl:
+          description: "TX_CTRL"
+          fields:
+            - name: force_tx_on
+              bit_offset: 0
+              bit_size: 1
+            - name: tx_loopback_mode
+              bit_offset: 1
+              bit_size: 1
+            - name: mod_method_ble
+              bit_offset: 2
+              bit_size: 1
+            - name: mod_method_br
+              bit_offset: 3
+              bit_size: 1
+            - name: mod_method_edr
+              bit_offset: 4
+              bit_size: 1
+            - name: mmdiv_sel
+              bit_offset: 5
+              bit_size: 1
+            - name: dac_sign
+              bit_offset: 6
+              bit_size: 1
+            - name: guard_time_sel
+              bit_offset: 7
+              bit_size: 2
+            - name: gfsk_rd_en
+              bit_offset: 9
+              bit_size: 1
+            - name: dpsk_rd_en
+              bit_offset: 10
+              bit_size: 1
+            - name: mac_mod_ctrl_en
+              bit_offset: 11
+              bit_size: 1
+            - name: tx_dc_cal_iq_swap
+              bit_offset: 12
+              bit_size: 1
+            - name: rcos_win_en
+              bit_offset: 13
+              bit_size: 1
+
+        fieldset/bt_phy::regs::TxRccCtrl:
+          description: "TX_RCC_CTRL"
+          fields:
+            - name: force_pa_ctrl_on
+              bit_offset: 0
+              bit_size: 1
+            - name: force_lfp_on
+              bit_offset: 1
+              bit_size: 1
+            - name: force_hfp_on
+              bit_offset: 2
+              bit_size: 1
+            - name: force_if_mod_on
+              bit_offset: 3
+              bit_size: 1
+            - name: force_rc_on
+              bit_offset: 4
+              bit_size: 1
+            - name: force_gaussflt_on
+              bit_offset: 5
+              bit_size: 1
+            - name: force_tx_reset
+              bit_offset: 6
+              bit_size: 1
+
+        fieldset/bt_phy::regs::TxGaussfltCfg1:
+          description: "TX_GAUSSFLT_CFG1"
+          fields:
+            - name: polar_gauss_gain_1
+              bit_offset: 0
+              bit_size: 9
+            - name: polar_gauss_gain_2
+              bit_offset: 9
+              bit_size: 9
+            - name: polar_gauss_gain_br
+              bit_offset: 18
+              bit_size: 9
+
+        fieldset/bt_phy::regs::TxGaussfltCfg2:
+          description: "TX_GAUSSFLT_CFG2"
+          fields:
+            - name: iq_gauss_gain_1
+              bit_offset: 0
+              bit_size: 9
+            - name: iq_gauss_gain_2
+              bit_offset: 9
+              bit_size: 9
+            - name: iq_gauss_gain_br
+              bit_offset: 18
+              bit_size: 9
+
+        fieldset/bt_phy::regs::TxIfModCfg:
+          description: "TX_IF_MOD_CFG"
+          fields:
+            - name: tx_if_phase_ble
+              bit_offset: 0
+              bit_size: 10
+            - name: tx_if_phase_br
+              bit_offset: 10
+              bit_size: 10
+            - name: tx_ramp_bypass
+              bit_offset: 20
+              bit_size: 1
+
+        fieldset/bt_phy::regs::TxIfModCfg2:
+          description: "TX_IF_MOD_CFG2"
+          fields:
+            - name: tx_mod_gain_ble_0
+              bit_offset: 0
+              bit_size: 8
+            - name: tx_mod_gain_ble_1
+              bit_offset: 8
+              bit_size: 8
+            - name: tx_mod_gain_ble_2
+              bit_offset: 16
+              bit_size: 8
+            - name: tx_mod_gain_ble_3
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_phy::regs::TxIfModCfg3:
+          description: "TX_IF_MOD_CFG3"
+          fields:
+            - name: tx_mod_gain_ble_4
+              bit_offset: 0
+              bit_size: 8
+            - name: tx_mod_gain_ble_5
+              bit_offset: 8
+              bit_size: 8
+            - name: tx_mod_gain_ble_6
+              bit_offset: 16
+              bit_size: 8
+            - name: tx_mod_gain_ble_7
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_phy::regs::TxIfModCfg4:
+          description: "TX_IF_MOD_CFG4"
+          fields:
+            - name: tx_mod_gain_br_0
+              bit_offset: 0
+              bit_size: 8
+            - name: tx_mod_gain_br_1
+              bit_offset: 8
+              bit_size: 8
+            - name: tx_mod_gain_br_2
+              bit_offset: 16
+              bit_size: 8
+            - name: tx_mod_gain_br_3
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_phy::regs::TxIfModCfg5:
+          description: "TX_IF_MOD_CFG5"
+          fields:
+            - name: tx_mod_gain_br_4
+              bit_offset: 0
+              bit_size: 8
+            - name: tx_mod_gain_br_5
+              bit_offset: 8
+              bit_size: 8
+            - name: tx_mod_gain_br_6
+              bit_offset: 16
+              bit_size: 8
+            - name: tx_mod_gain_br_7
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_phy::regs::TxIfModCfg6:
+          description: "TX_IF_MOD_CFG6"
+          fields:
+            - name: tx_mod_gain_edr_0
+              bit_offset: 0
+              bit_size: 8
+            - name: tx_mod_gain_edr_1
+              bit_offset: 8
+              bit_size: 8
+            - name: tx_mod_gain_edr_2
+              bit_offset: 16
+              bit_size: 8
+            - name: tx_mod_gain_edr_3
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_phy::regs::TxIfModCfg7:
+          description: "TX_IF_MOD_CFG7"
+          fields:
+            - name: tx_mod_gain_edr_4
+              bit_offset: 0
+              bit_size: 8
+            - name: tx_mod_gain_edr_5
+              bit_offset: 8
+              bit_size: 8
+            - name: tx_mod_gain_edr_6
+              bit_offset: 16
+              bit_size: 8
+            - name: tx_mod_gain_edr_7
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_phy::regs::TxHfpCfg:
+          description: "TX_HFP_CFG"
+          fields:
+            - name: tx_kcal_coef
+              bit_offset: 0
+              bit_size: 9
+            - name: tx_kcal
+              bit_offset: 9
+              bit_size: 12
+            - name: hfp_fcw_sel
+              bit_offset: 21
+              bit_size: 1
+            - name: hfp_fcw
+              bit_offset: 22
+              bit_size: 6
+            - name: hfp_delay_sel
+              bit_offset: 28
+              bit_size: 3
+
+        fieldset/bt_phy::regs::TxLfpCfg:
+          description: "TX_LFP_CFG"
+          fields:
+            - name: lfp_fcw_sel
+              bit_offset: 0
+              bit_size: 1
+            - name: lfp_fcw
+              bit_offset: 1
+              bit_size: 10
+            - name: tx_sdm_dither_en
+              bit_offset: 11
+              bit_size: 2
+            - name: tx_sdm_sel
+              bit_offset: 13
+              bit_size: 1
+
+        fieldset/bt_phy::regs::TxPaCfg:
+          description: "TX_PA_CFG"
+          fields:
+            - name: pa_ramp_force
+              bit_offset: 0
+              bit_size: 2
+            - name: pa_ramp_factor_idx
+              bit_offset: 2
+              bit_size: 3
+
+        fieldset/bt_phy::regs::TxDpskCfg1:
+          description: "TX_DPSK_CFG1"
+          fields:
+            - name: tx_dpsk_gain_0
+              bit_offset: 0
+              bit_size: 8
+            - name: tx_dpsk_gain_1
+              bit_offset: 8
+              bit_size: 8
+            - name: tx_dpsk_gain_2
+              bit_offset: 16
+              bit_size: 8
+            - name: tx_dpsk_gain_3
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_phy::regs::TxDpskCfg2:
+          description: "TX_DPSK_CFG2"
+          fields:
+            - name: tx_dpsk_gain_4
+              bit_offset: 0
+              bit_size: 8
+            - name: tx_dpsk_gain_5
+              bit_offset: 8
+              bit_size: 8
+            - name: tx_dpsk_gain_6
+              bit_offset: 16
+              bit_size: 8
+            - name: tx_dpsk_gain_7
+              bit_offset: 24
+              bit_size: 8
+
+        fieldset/bt_phy::regs::TxDcCalCfg0:
+          description: "TX_DC_CAL_CFG0"
+          fields:
+            - name: tx_dc_cal_phase0
+              bit_offset: 0
+              bit_size: 10
+            - name: tx_dc_cal_phase1
+              bit_offset: 10
+              bit_size: 10
+            - name: tx_dc_cal_en
+              bit_offset: 20
+              bit_size: 1
+
+        fieldset/bt_phy::regs::TxDcCalCfg1:
+          description: "TX_DC_CAL_CFG1"
+          fields:
+            - name: tx_dc_cal_phase_init0
+              bit_offset: 0
+              bit_size: 10
+            - name: tx_dc_cal_phase_init1
+              bit_offset: 10
+              bit_size: 10
+
+        fieldset/bt_phy::regs::TxDcCalCfg2:
+          description: "TX_DC_CAL_CFG2"
+          fields:
+            - name: tx_dc_cal_gain0
+              bit_offset: 0
+              bit_size: 8
+            - name: tx_dc_cal_gain1
+              bit_offset: 8
+              bit_size: 8
+
+        fieldset/bt_phy::regs::LfpMmdivCfg0:
+          description: "LFP_MMDIV_CFG0"
+          fields:
+            - name: rx_mmdiv_offset_1m
+              bit_offset: 0
+              bit_size: 17
+
+        fieldset/bt_phy::regs::LfpMmdivCfg1:
+          description: "LFP_MMDIV_CFG1"
+          fields:
+            - name: rx_mmdiv_offset_2m
+              bit_offset: 0
+              bit_size: 17
+
+        fieldset/bt_phy::regs::LfpMmdivCfg2:
+          description: "LFP_MMDIV_CFG2"
+          fields:
+            - name: rx_mmdiv_offset_bt
+              bit_offset: 0
+              bit_size: 17
+
+        fieldset/bt_phy::regs::LfpMmdivCfg3:
+          description: "LFP_MMDIV_CFG3"
+          fields:
+            - name: tx_mmdiv_offset
+              bit_offset: 0
+              bit_size: 17
+
+        fieldset/bt_phy::regs::LfpMmdivCfg4:
+          description: "LFP_MMDIV_CFG4"
+          fields:
+            - name: rf_mmdiv_test
+              bit_offset: 0
+              bit_size: 25
+            - name: rf_test_mode
+              bit_offset: 25
+              bit_size: 1
+
+        fieldset/bt_phy::regs::RxHfpCfg:
+          description: "RX_HFP_CFG"
+          fields:
+            - name: rx_hfp_fcw
+              bit_offset: 0
+              bit_size: 6
+
+        fieldset/bt_phy::regs::LnaGainTbl0:
+          description: "LNA_GAIN_TBL0"
+          fields:
+            - name: lna_gain_0
+              bit_offset: 0
+              bit_size: 11
+            - name: lna_gain_1
+              bit_offset: 11
+              bit_size: 11
+
+        fieldset/bt_phy::regs::LnaGainTbl1:
+          description: "LNA_GAIN_TBL1"
+          fields:
+            - name: lna_gain_2
+              bit_offset: 0
+              bit_size: 11
+            - name: lna_gain_3
+              bit_offset: 11
+              bit_size: 11
+
+        fieldset/bt_phy::regs::LnaGainTbl2:
+          description: "LNA_GAIN_TBL2"
+          fields:
+            - name: lna_gain_4
+              bit_offset: 0
+              bit_size: 11
+            - name: lna_gain_5
+              bit_offset: 11
+              bit_size: 11
+
+        fieldset/bt_phy::regs::LnaGainTbl3:
+          description: "LNA_GAIN_TBL3"
+          fields:
+            - name: lna_gain_6
+              bit_offset: 0
+              bit_size: 11
+            - name: lna_gain_7
+              bit_offset: 11
+              bit_size: 11
+
+        fieldset/bt_phy::regs::LnaGainTbl4:
+          description: "LNA_GAIN_TBL4"
+          fields:
+            - name: lna_gain_8
+              bit_offset: 0
+              bit_size: 11
+            - name: lna_gain_9
+              bit_offset: 11
+              bit_size: 11
+
+        fieldset/bt_phy::regs::LnaGainTbl5:
+          description: "LNA_GAIN_TBL5"
+          fields:
+            - name: lna_gain_10
+              bit_offset: 0
+              bit_size: 11
+            - name: lna_gain_11
+              bit_offset: 11
+              bit_size: 11
+
+        fieldset/bt_phy::regs::RcosCfg0:
+          description: "RCOS_CFG0"
+          fields:
+            - name: rcos_coef_0
+              bit_offset: 0
+              bit_size: 12
+            - name: rcos_coef_1
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::RcosCfg1:
+          description: "RCOS_CFG1"
+          fields:
+            - name: rcos_coef_2
+              bit_offset: 0
+              bit_size: 12
+            - name: rcos_coef_3
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::RcosCfg2:
+          description: "RCOS_CFG2"
+          fields:
+            - name: rcos_coef_4
+              bit_offset: 0
+              bit_size: 12
+            - name: rcos_coef_5
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::RcosCfg3:
+          description: "RCOS_CFG3"
+          fields:
+            - name: rcos_coef_6
+              bit_offset: 0
+              bit_size: 12
+            - name: rcos_coef_7
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::RcosCfg4:
+          description: "RCOS_CFG4"
+          fields:
+            - name: rcos_coef_8
+              bit_offset: 0
+              bit_size: 12
+            - name: rcos_coef_9
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::RcosCfg5:
+          description: "RCOS_CFG5"
+          fields:
+            - name: rcos_coef_10
+              bit_offset: 0
+              bit_size: 12
+            - name: rcos_coef_11
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::RcosCfg6:
+          description: "RCOS_CFG6"
+          fields:
+            - name: rcos_coef_12
+              bit_offset: 0
+              bit_size: 12
+            - name: rcos_coef_13
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::RcosCfg7:
+          description: "RCOS_CFG7"
+          fields:
+            - name: rcos_coef_14
+              bit_offset: 0
+              bit_size: 12
+            - name: rcos_coef_15
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::RcosCfg8:
+          description: "RCOS_CFG8"
+          fields:
+            - name: rcos_coef_16
+              bit_offset: 0
+              bit_size: 12
+            - name: rcos_coef_17
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::RcosCfg9:
+          description: "RCOS_CFG9"
+          fields:
+            - name: rcos_coef_18
+              bit_offset: 0
+              bit_size: 12
+            - name: rcos_coef_19
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::RcosCfg10:
+          description: "RCOS_CFG10"
+          fields:
+            - name: rcos_coef_20
+              bit_offset: 0
+              bit_size: 12
+            - name: rcos_coef_21
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::RcosCfg11:
+          description: "RCOS_CFG11"
+          fields:
+            - name: rcos_coef_22
+              bit_offset: 0
+              bit_size: 12
+            - name: rcos_coef_23
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::RcosCfg12:
+          description: "RCOS_CFG12"
+          fields:
+            - name: rcos_coef_24
+              bit_offset: 0
+              bit_size: 12
+            - name: rcos_coef_25
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::RcosCfg13:
+          description: "RCOS_CFG13"
+          fields:
+            - name: rcos_coef_26
+              bit_offset: 0
+              bit_size: 12
+            - name: rcos_coef_27
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::RcosCfg14:
+          description: "RCOS_CFG14"
+          fields:
+            - name: rcos_coef_28
+              bit_offset: 0
+              bit_size: 12
+            - name: rcos_coef_29
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::RcosCfg15:
+          description: "RCOS_CFG15"
+          fields:
+            - name: rcos_coef_30
+              bit_offset: 0
+              bit_size: 12
+            - name: rcos_coef_31
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::RcosCfg16:
+          description: "RCOS_CFG16"
+          fields:
+            - name: rcos_coef_32
+              bit_offset: 0
+              bit_size: 12
+            - name: rcos_coef_33
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::RcosCfg17:
+          description: "RCOS_CFG17"
+          fields:
+            - name: rcos_coef_34
+              bit_offset: 0
+              bit_size: 12
+            - name: rcos_coef_35
+              bit_offset: 12
+              bit_size: 12
+
+        fieldset/bt_phy::regs::RcosCfg18:
+          description: "RCOS_CFG18"
+          fields:
+            - name: rcos_coef_36
+              bit_offset: 0
+              bit_size: 12
+
+        fieldset/bt_phy::regs::LpfCfg0:
+          description: "LPF_CFG0"
+          fields:
+            - name: lpf_coef_0
+              bit_offset: 0
+              bit_size: 9
+            - name: lpf_coef_1
+              bit_offset: 9
+              bit_size: 9
+            - name: lpf_coef_2
+              bit_offset: 18
+              bit_size: 9
+
+        fieldset/bt_phy::regs::LpfCfg1:
+          description: "LPF_CFG1"
+          fields:
+            - name: lpf_coef_3
+              bit_offset: 0
+              bit_size: 9
+            - name: lpf_coef_4
+              bit_offset: 9
+              bit_size: 9
+            - name: lpf_coef_5
+              bit_offset: 18
+              bit_size: 9
+
+        fieldset/bt_phy::regs::LpfCfg2:
+          description: "LPF_CFG2"
+          fields:
+            - name: lpf_coef_6
+              bit_offset: 0
+              bit_size: 9
+            - name: lpf_coef_7
+              bit_offset: 9
+              bit_size: 9
+            - name: lpf_coef_8
+              bit_offset: 18
+              bit_size: 9
+
+        fieldset/bt_phy::regs::LpfCfg3:
+          description: "LPF_CFG3"
+          fields:
+            - name: lpf_coef_9
+              bit_offset: 0
+              bit_size: 9

--- a/transform/common/bt_rfc.yaml
+++ b/transform/common/bt_rfc.yaml
@@ -1,3 +1,13 @@
+# BT_RFC Peripheral Definition
+#
+# WARNING: This file contains register definitions derived from reverse-engineering
+# the SiFli C SDK. These are NOT official SVD definitions from the vendor.
+#
+# Source: SiFli-SDK headers and register maps
+# The vendor has declined to include Bluetooth-related registers in the official SVD.
+#
+# Use at your own risk. Register layouts may be incomplete or inaccurate.
+
 transforms:
 
   - !AddPeripherals

--- a/transform/common/bt_rfc.yaml
+++ b/transform/common/bt_rfc.yaml
@@ -1,0 +1,1270 @@
+transforms:
+
+  - !AddPeripherals
+      devices: .*
+      peripherals:
+        - name: BT_RFC
+          base_address: 0x40082800
+          block: bt_rfc::BtRfc
+
+  - !Add
+      ir:
+        block/bt_rfc::BtRfc:
+          items:
+            - name: vco_reg1
+              byte_offset: 0x0
+              fieldset: bt_rfc::regs::VcoReg1
+            - name: vco_reg2
+              byte_offset: 0x4
+              fieldset: bt_rfc::regs::VcoReg2
+            - name: vco_reg3
+              byte_offset: 0x8
+              fieldset: bt_rfc::regs::VcoReg3
+            - name: misc_ctrl_reg
+              byte_offset: 0xc
+              fieldset: bt_rfc::regs::MiscCtrlReg
+            - name: rf_lodist_reg
+              byte_offset: 0x10
+              fieldset: bt_rfc::regs::RfLodistReg
+            - name: fbdv_reg1
+              byte_offset: 0x14
+              fieldset: bt_rfc::regs::FbdvReg1
+            - name: fbdv_reg2
+              byte_offset: 0x18
+              fieldset: bt_rfc::regs::FbdvReg2
+            - name: pfdcp_reg
+              byte_offset: 0x1c
+              fieldset: bt_rfc::regs::PfdcpReg
+            - name: lpf_reg
+              byte_offset: 0x20
+              fieldset: bt_rfc::regs::LpfReg
+            - name: edr_cal_reg1
+              byte_offset: 0x24
+              fieldset: bt_rfc::regs::EdrCalReg1
+            - name: oslo_reg
+              byte_offset: 0x28
+              fieldset: bt_rfc::regs::OsloReg
+            - name: atest_reg
+              byte_offset: 0x2c
+              fieldset: bt_rfc::regs::AtestReg
+            - name: dtest_reg
+              byte_offset: 0x30
+              fieldset: bt_rfc::regs::DtestReg
+            - name: trf_reg1
+              byte_offset: 0x34
+              fieldset: bt_rfc::regs::TrfReg1
+            - name: trf_reg2
+              byte_offset: 0x38
+              fieldset: bt_rfc::regs::TrfReg2
+            - name: trf_edr_reg1
+              byte_offset: 0x3c
+              fieldset: bt_rfc::regs::TrfEdrReg1
+            - name: trf_edr_reg2
+              byte_offset: 0x40
+              fieldset: bt_rfc::regs::TrfEdrReg2
+            - name: rrf_reg
+              byte_offset: 0x44
+              fieldset: bt_rfc::regs::RrfReg
+            - name: rbb_reg1
+              byte_offset: 0x48
+              fieldset: bt_rfc::regs::RbbReg1
+            - name: rbb_reg2
+              byte_offset: 0x4c
+              fieldset: bt_rfc::regs::RbbReg2
+            - name: rbb_reg3
+              byte_offset: 0x50
+              fieldset: bt_rfc::regs::RbbReg3
+            - name: rbb_reg4
+              byte_offset: 0x54
+              fieldset: bt_rfc::regs::RbbReg4
+            - name: rbb_reg5
+              byte_offset: 0x58
+              fieldset: bt_rfc::regs::RbbReg5
+            - name: rbb_reg6
+              byte_offset: 0x5c
+              fieldset: bt_rfc::regs::RbbReg6
+            - name: adc_reg
+              byte_offset: 0x60
+              fieldset: bt_rfc::regs::AdcReg
+            - name: tbb_reg
+              byte_offset: 0x64
+              fieldset: bt_rfc::regs::TbbReg
+            - name: atstbuf_reg
+              byte_offset: 0x68
+              fieldset: bt_rfc::regs::AtstbufReg
+            - name: inccal_reg1
+              byte_offset: 0x74
+              fieldset: bt_rfc::regs::InccalReg1
+            - name: inccal_reg2
+              byte_offset: 0x78
+              fieldset: bt_rfc::regs::InccalReg2
+            - name: roscal_reg1
+              byte_offset: 0x7c
+              fieldset: bt_rfc::regs::RoscalReg1
+            - name: roscal_reg2
+              byte_offset: 0x80
+              fieldset: bt_rfc::regs::RoscalReg2
+            - name: rcroscal_reg
+              byte_offset: 0x84
+              fieldset: bt_rfc::regs::RcroscalReg
+            - name: pacal_reg
+              byte_offset: 0x88
+              fieldset: bt_rfc::regs::PacalReg
+            - name: cu_addr_reg1
+              byte_offset: 0x8c
+              fieldset: bt_rfc::regs::CuAddrReg1
+            - name: cu_addr_reg2
+              byte_offset: 0x90
+              fieldset: bt_rfc::regs::CuAddrReg2
+            - name: cu_addr_reg3
+              byte_offset: 0x94
+              fieldset: bt_rfc::regs::CuAddrReg3
+            - name: cal_addr_reg1
+              byte_offset: 0x98
+              fieldset: bt_rfc::regs::CalAddrReg1
+            - name: cal_addr_reg2
+              byte_offset: 0x9c
+              fieldset: bt_rfc::regs::CalAddrReg2
+            - name: cal_addr_reg3
+              byte_offset: 0xa0
+              fieldset: bt_rfc::regs::CalAddrReg3
+            - name: agc_reg
+              byte_offset: 0xa4
+              fieldset: bt_rfc::regs::AgcReg
+            - name: iq_pwr_reg1
+              byte_offset: 0xa8
+              fieldset: bt_rfc::regs::IqPwrReg1
+            - name: iq_pwr_reg2
+              byte_offset: 0xac
+              fieldset: bt_rfc::regs::IqPwrReg2
+
+        fieldset/bt_rfc::regs::VcoReg1:
+          description: "VCO_REG1"
+          fields:
+            - name: brf_en_2m_mod_lv
+              bit_offset: 0
+              bit_size: 1
+            - name: brf_vco_var_vvn_bm_lv
+              bit_offset: 1
+              bit_size: 3
+            - name: brf_vco_cbank_vvn_bm_lv
+              bit_offset: 4
+              bit_size: 3
+            - name: brf_vco_flt_en_lv
+              bit_offset: 7
+              bit_size: 1
+            - name: brf_vco_ldo_vref_lv
+              bit_offset: 8
+              bit_size: 4
+            - name: brf_vco5g_en_lv
+              bit_offset: 12
+              bit_size: 1
+            - name: brf_vco3g_en_lv
+              bit_offset: 13
+              bit_size: 1
+
+        fieldset/bt_rfc::regs::VcoReg2:
+          description: "VCO_REG2"
+          fields:
+            - name: brf_vco_acal_vl_sel_lv
+              bit_offset: 0
+              bit_size: 4
+            - name: brf_vco_acal_vh_sel_lv
+              bit_offset: 4
+              bit_size: 4
+            - name: brf_vco_acal_en_lv
+              bit_offset: 8
+              bit_size: 1
+            - name: brf_vco_incfcal_vl_sel_lv
+              bit_offset: 9
+              bit_size: 3
+            - name: brf_vco_incfcal_vh_sel_lv
+              bit_offset: 12
+              bit_size: 3
+            - name: brf_vco_incfcal_en_lv
+              bit_offset: 15
+              bit_size: 1
+            - name: brf_vco_fkcal_vc_sel_lv
+              bit_offset: 16
+              bit_size: 3
+            - name: brf_vco_fkcal_en_lv
+              bit_offset: 19
+              bit_size: 1
+            - name: brf_en_mod_inphase_lv
+              bit_offset: 20
+              bit_size: 1
+            - name: brf_vco3g_acal_up_lv
+              bit_offset: 21
+              bit_size: 1
+            - name: brf_vco3g_acal_incal_lv
+              bit_offset: 22
+              bit_size: 1
+            - name: brf_vco3g_incfcal_up_lv
+              bit_offset: 23
+              bit_size: 1
+            - name: brf_vco3g_incfcal_incal_lv
+              bit_offset: 24
+              bit_size: 1
+            - name: brf_vco5g_acal_up_lv
+              bit_offset: 25
+              bit_size: 1
+            - name: brf_vco5g_acal_incal_lv
+              bit_offset: 26
+              bit_size: 1
+            - name: brf_vco5g_incfcal_up_lv
+              bit_offset: 27
+              bit_size: 1
+            - name: brf_vco5g_incfcal_incal_lv
+              bit_offset: 28
+              bit_size: 1
+
+        fieldset/bt_rfc::regs::VcoReg3:
+          description: "VCO_REG3"
+          fields:
+            - name: brf_vco_pdx_lv
+              bit_offset: 0
+              bit_size: 8
+            - name: brf_vco_idac_lv
+              bit_offset: 8
+              bit_size: 7
+            - name: tx_kcal
+              bit_offset: 16
+              bit_size: 12
+
+        fieldset/bt_rfc::regs::MiscCtrlReg:
+          description: "MISC_CTRL_REG"
+          fields:
+            - name: pdx_force_en
+              bit_offset: 0
+              bit_size: 1
+            - name: idac_force_en
+              bit_offset: 1
+              bit_size: 1
+            - name: xtal_ref_en
+              bit_offset: 2
+              bit_size: 1
+            - name: adc_clk_en
+              bit_offset: 3
+              bit_size: 1
+            - name: adc_fifo_clk_phase_sel
+              bit_offset: 4
+              bit_size: 1
+            - name: unlock_flag_clr
+              bit_offset: 5
+              bit_size: 1
+            - name: xtal_ref_en_frc_en
+              bit_offset: 6
+              bit_size: 1
+            - name: adc_clk_en_frc_en
+              bit_offset: 7
+              bit_size: 1
+            - name: adc_clk_sel
+              bit_offset: 8
+              bit_size: 1
+            - name: adc_clk_sel_frc_en
+              bit_offset: 9
+              bit_size: 1
+            - name: cbpf_bw_frc_en
+              bit_offset: 10
+              bit_size: 1
+            - name: cbpf_wx2_stg1_frc_en
+              bit_offset: 11
+              bit_size: 1
+            - name: cbpf_wx2_stg2_frc_en
+              bit_offset: 12
+              bit_size: 1
+            - name: rvga_wx2_stg1_frc_en
+              bit_offset: 13
+              bit_size: 1
+            - name: rvga_wx2_stg2_frc_en
+              bit_offset: 14
+              bit_size: 1
+            - name: pkdet_en_early_off_en
+              bit_offset: 15
+              bit_size: 1
+            - name: xtal_rfch_sel_en
+              bit_offset: 16
+              bit_size: 1
+            - name: iq_swap_en
+              bit_offset: 17
+              bit_size: 1
+            - name: bt_xtal_ref_en
+              bit_offset: 18
+              bit_size: 1
+            - name: dac_clk_en
+              bit_offset: 19
+              bit_size: 1
+            - name: edr_unlock_flag_clr
+              bit_offset: 20
+              bit_size: 1
+            - name: edr_xtal_ref_en
+              bit_offset: 21
+              bit_size: 1
+            - name: edr_xtal_ref_en_frc_en
+              bit_offset: 22
+              bit_size: 1
+            - name: dac_clk_en_frc_en
+              bit_offset: 23
+              bit_size: 1
+            - name: bypass_dac_fifo
+              bit_offset: 24
+              bit_size: 1
+            - name: dac_wclk_edge_sel
+              bit_offset: 25
+              bit_size: 1
+            - name: adc_q_en_frc_en
+              bit_offset: 26
+              bit_size: 1
+            - name: en_2m_mod_frc_en
+              bit_offset: 27
+              bit_size: 1
+
+        fieldset/bt_rfc::regs::RfLodistReg:
+          description: "RF_LODIST_REG"
+          fields:
+            - name: brf_lodistedr_en_lv
+              bit_offset: 0
+              bit_size: 1
+            - name: brf_lodistedr_ldo_vref_lv
+              bit_offset: 1
+              bit_size: 4
+            - name: brf_lodistedr_tx_sel_lv
+              bit_offset: 5
+              bit_size: 2
+            - name: brf_lodist5g_edrtx_en_lv
+              bit_offset: 7
+              bit_size: 1
+            - name: brf_lodist5g_bletx_en_lv
+              bit_offset: 8
+              bit_size: 1
+            - name: brf_lodist5g_rx_en_lv
+              bit_offset: 9
+              bit_size: 1
+            - name: brf_lodist5g_fbdv_str_lv
+              bit_offset: 10
+              bit_size: 2
+            - name: brf_lodist5g_tx_str_lv
+              bit_offset: 12
+              bit_size: 2
+            - name: brf_lodist5g_rx_str_lv
+              bit_offset: 14
+              bit_size: 2
+            - name: brf_lo_iary_en_lv
+              bit_offset: 16
+              bit_size: 1
+            - name: brf_en_rfbg_lv
+              bit_offset: 17
+              bit_size: 1
+            - name: brf_en_vddpsw_lv
+              bit_offset: 18
+              bit_size: 1
+
+        fieldset/bt_rfc::regs::FbdvReg1:
+          description: "FBDV_REG1"
+          fields:
+            - name: brf_fkcal_cnt_rdy_lv
+              bit_offset: 0
+              bit_size: 1
+            - name: brf_fkcal_cnt_rstb_lv
+              bit_offset: 1
+              bit_size: 1
+            - name: brf_fkcal_cnt_en_lv
+              bit_offset: 2
+              bit_size: 1
+            - name: brf_sdm_clk_sel_lv
+              bit_offset: 3
+              bit_size: 1
+            - name: brf_fbdv_mod_stg_lv
+              bit_offset: 4
+              bit_size: 2
+            - name: brf_fbdv_rstb_sync_en_lv
+              bit_offset: 6
+              bit_size: 1
+            - name: brf_fbdv_rstb_lv
+              bit_offset: 7
+              bit_size: 1
+            - name: brf_fbdv_ldo_vref_lv
+              bit_offset: 8
+              bit_size: 4
+            - name: brf_fbdv_en_lv
+              bit_offset: 12
+              bit_size: 1
+
+        fieldset/bt_rfc::regs::FbdvReg2:
+          description: "FBDV_REG2"
+          fields:
+            - name: brf_fkcal_cnt_divn_lv
+              bit_offset: 0
+              bit_size: 16
+            - name: brf_fkcal_cnt_op_lv
+              bit_offset: 16
+              bit_size: 16
+
+        fieldset/bt_rfc::regs::PfdcpReg:
+          description: "PFDCP_REG"
+          fields:
+            - name: brf_csd_dn_lv
+              bit_offset: 0
+              bit_size: 1
+            - name: brf_csd_up_lv
+              bit_offset: 1
+              bit_size: 1
+            - name: brf_lo_unlock_lv
+              bit_offset: 2
+              bit_size: 1
+            - name: brf_pfdcp_csd_reset_lv
+              bit_offset: 3
+              bit_size: 1
+            - name: brf_pfdcp_csd_en_lv
+              bit_offset: 4
+              bit_size: 1
+            - name: brf_pfdcp_icp_os_lv
+              bit_offset: 5
+              bit_size: 6
+            - name: brf_pfdcp_icp_set_lv
+              bit_offset: 11
+              bit_size: 4
+            - name: brf_pfdcp_ldo_vref_lv
+              bit_offset: 15
+              bit_size: 4
+            - name: brf_pfdcp_en_lv
+              bit_offset: 19
+              bit_size: 1
+
+        fieldset/bt_rfc::regs::LpfReg:
+          description: "LPF_REG"
+          fields:
+            - name: brf_lpf_rz_sel_lv
+              bit_offset: 0
+              bit_size: 3
+            - name: brf_lpf_rp4_sel_lv
+              bit_offset: 3
+              bit_size: 3
+            - name: brf_lpf_cz_sel_lv
+              bit_offset: 6
+              bit_size: 3
+            - name: brf_lpf_cp4_sel_lv
+              bit_offset: 9
+              bit_size: 2
+            - name: brf_lpf_cp3_sel_lv
+              bit_offset: 11
+              bit_size: 3
+            - name: brf_lo_open_lv
+              bit_offset: 14
+              bit_size: 1
+
+        fieldset/bt_rfc::regs::EdrCalReg1:
+          description: "EDR_CAL_REG1"
+          fields:
+            - name: brf_edr_vco_pdx_lv
+              bit_offset: 0
+              bit_size: 8
+            - name: brf_edr_vco_idac_lv
+              bit_offset: 8
+              bit_size: 7
+            - name: brf_oslo_fc_lv
+              bit_offset: 16
+              bit_size: 3
+            - name: brf_oslo_bm_lv
+              bit_offset: 20
+              bit_size: 5
+            - name: brf_trf_edr_tmxcap_sel_lv
+              bit_offset: 28
+              bit_size: 4
+
+        fieldset/bt_rfc::regs::OsloReg:
+          description: "OSLO_REG"
+          fields:
+            - name: brf_oslo_acal_cmp_lv
+              bit_offset: 0
+              bit_size: 1
+            - name: brf_oslo_pkdet_en_lv
+              bit_offset: 1
+              bit_size: 1
+            - name: brf_oslo_ngm_en_lv
+              bit_offset: 2
+              bit_size: 1
+            - name: brf_oslo_fcal_en_lv
+              bit_offset: 3
+              bit_size: 1
+            - name: brf_oslo_pkdet_vref_lv
+              bit_offset: 4
+              bit_size: 3
+            - name: brf_oslo_ldo_vref_lv
+              bit_offset: 7
+              bit_size: 4
+            - name: brf_oslo_en_lv
+              bit_offset: 11
+              bit_size: 1
+
+        fieldset/bt_rfc::regs::AtestReg:
+          description: "ATEST_REG"
+          fields:
+            - name: brf_dc_tr_lv
+              bit_offset: 0
+              bit_size: 3
+            - name: brf_dc_br_lv
+              bit_offset: 3
+              bit_size: 3
+            - name: brf_dc_mr_lv
+              bit_offset: 6
+              bit_size: 3
+
+        fieldset/bt_rfc::regs::DtestReg:
+          description: "DTEST_REG"
+          fields:
+            - name: brf_fbdv_dtest_tr_lv
+              bit_offset: 0
+              bit_size: 4
+            - name: brf_fbdv_dtest_en_lv
+              bit_offset: 4
+              bit_size: 1
+
+        fieldset/bt_rfc::regs::TrfReg1:
+          description: "TRF_REG1"
+          fields:
+            - name: brf_pa_cas_bp_lv
+              bit_offset: 0
+              bit_size: 1
+            - name: brf_pa_pm_lv
+              bit_offset: 1
+              bit_size: 2
+            - name: brf_pa_vc_lv
+              bit_offset: 3
+              bit_size: 6
+            - name: brf_pa_rstn_lv
+              bit_offset: 9
+              bit_size: 1
+            - name: brf_pa_setbc_lv
+              bit_offset: 10
+              bit_size: 4
+            - name: brf_pa_setsgn_lv
+              bit_offset: 14
+              bit_size: 1
+            - name: brf_pa_bcsel_lv
+              bit_offset: 15
+              bit_size: 1
+            - name: brf_trf_sig_en_lv
+              bit_offset: 16
+              bit_size: 1
+            - name: brf_trf_ldo_vref_sel_lv
+              bit_offset: 17
+              bit_size: 4
+            - name: brf_pa_out_pu_lv
+              bit_offset: 21
+              bit_size: 1
+            - name: brf_pa_buf_pu_lv
+              bit_offset: 22
+              bit_size: 1
+
+        fieldset/bt_rfc::regs::TrfReg2:
+          description: "TRF_REG2"
+          fields:
+            - name: brf_pa_atten_gain_lv
+              bit_offset: 0
+              bit_size: 4
+            - name: brf_pa_atten_en_lv
+              bit_offset: 4
+              bit_size: 1
+            - name: brf_pa_match2_lv
+              bit_offset: 5
+              bit_size: 2
+            - name: brf_pa_match1_lv
+              bit_offset: 7
+              bit_size: 2
+            - name: brf_pa_tx_rx_lv
+              bit_offset: 9
+              bit_size: 1
+            - name: brf_pa_mcap_lv
+              bit_offset: 10
+              bit_size: 1
+            - name: brf_pa_unit_sel_lv
+              bit_offset: 11
+              bit_size: 5
+            - name: brf_pa_bufload_sel_lv
+              bit_offset: 16
+              bit_size: 2
+            - name: brf_pa_bm_lv
+              bit_offset: 18
+              bit_size: 2
+
+        fieldset/bt_rfc::regs::TrfEdrReg1:
+          description: "TRF_EDR_REG1"
+          fields:
+            - name: brf_trf_edr_pacas_bm_lv
+              bit_offset: 0
+              bit_size: 2
+            - name: brf_trf_edr_pa_pu_lv
+              bit_offset: 2
+              bit_size: 1
+            - name: brf_trf_edr_tmxcap_bm_lv
+              bit_offset: 3
+              bit_size: 2
+            - name: brf_trf_edr_tmxcap_sel_lv
+              bit_offset: 5
+              bit_size: 4
+            - name: brf_trf_edr_tmxcas_bm_lv
+              bit_offset: 9
+              bit_size: 2
+            - name: brf_trf_edr_tmxcas_sel_lv
+              bit_offset: 11
+              bit_size: 1
+            - name: brf_trf_edr_tmx_pu_lv
+              bit_offset: 12
+              bit_size: 1
+            - name: brf_trf_edr_lobias_bm_lv
+              bit_offset: 13
+              bit_size: 2
+            - name: brf_trf_edr_tmxbuf_ibld_lv
+              bit_offset: 15
+              bit_size: 4
+            - name: brf_trf_edr_tmxbuf_pu_lv
+              bit_offset: 19
+              bit_size: 1
+            - name: brf_trf_edr_iarray_en_lv
+              bit_offset: 20
+              bit_size: 1
+
+        fieldset/bt_rfc::regs::TrfEdrReg2:
+          description: "TRF_EDR_REG2"
+          fields:
+            - name: brf_trf_edr_pwrmtr_os_pn_lv
+              bit_offset: 0
+              bit_size: 1
+            - name: brf_trf_edr_pwrmtr_os_lv
+              bit_offset: 1
+              bit_size: 4
+            - name: brf_trf_edr_pwrmtr_gc_lv
+              bit_offset: 5
+              bit_size: 2
+            - name: brf_trf_edr_pwrmtr_bm_lv
+              bit_offset: 7
+              bit_size: 3
+            - name: brf_trf_edr_pwrmtr_en_lv
+              bit_offset: 10
+              bit_size: 1
+            - name: brf_trf_edr_pa_xfmr_sg_lv
+              bit_offset: 11
+              bit_size: 1
+            - name: brf_trf_edr_papmos_bm_lv
+              bit_offset: 12
+              bit_size: 3
+            - name: brf_trf_edr_pacap_bm_lv
+              bit_offset: 15
+              bit_size: 2
+            - name: brf_trf_edr_pacap_en_lv
+              bit_offset: 17
+              bit_size: 1
+
+        fieldset/bt_rfc::regs::RrfReg:
+          description: "RRF_REG"
+          fields:
+            - name: brf_mx_bm_lv
+              bit_offset: 0
+              bit_size: 3
+            - name: brf_mx_pu_lv
+              bit_offset: 3
+              bit_size: 1
+            - name: brf_lna_match_lv
+              bit_offset: 4
+              bit_size: 2
+            - name: brf_lna_shuntsw_lv
+              bit_offset: 6
+              bit_size: 1
+            - name: brf_lna_fbrtrim_lv
+              bit_offset: 7
+              bit_size: 3
+            - name: brf_lna_gc_lv
+              bit_offset: 10
+              bit_size: 4
+            - name: brf_lna_bm_lv
+              bit_offset: 14
+              bit_size: 3
+            - name: brf_lna_pu_lv
+              bit_offset: 17
+              bit_size: 1
+            - name: brf_rrf_ldo_vref_sel_lv
+              bit_offset: 18
+              bit_size: 4
+            - name: brf_rrf_ldo11_en_lv
+              bit_offset: 22
+              bit_size: 1
+
+        fieldset/bt_rfc::regs::RbbReg1:
+          description: "RBB_REG1"
+          fields:
+            - name: brf_cbpf_fc_lv_2m
+              bit_offset: 0
+              bit_size: 2
+            - name: brf_cbpf_bm_lv_2m
+              bit_offset: 2
+              bit_size: 3
+            - name: brf_cbpf_cc_lv_2m
+              bit_offset: 5
+              bit_size: 4
+            - name: brf_sel_ldovref_rbb_lv
+              bit_offset: 9
+              bit_size: 4
+            - name: brf_en_ldo_rbb_lv
+              bit_offset: 13
+              bit_size: 1
+            - name: brf_pkdet_vth2q_bt
+              bit_offset: 14
+              bit_size: 4
+            - name: brf_pkdet_vth2i_bt
+              bit_offset: 18
+              bit_size: 4
+            - name: brf_pkdet_vth1q_bt
+              bit_offset: 22
+              bit_size: 4
+            - name: brf_pkdet_vth1i_bt
+              bit_offset: 26
+              bit_size: 4
+
+        fieldset/bt_rfc::regs::RbbReg2:
+          description: "RBB_REG2"
+          fields:
+            - name: brf_rvga_man_cfsel_lv
+              bit_offset: 0
+              bit_size: 1
+            - name: brf_rvga_gc_lv
+              bit_offset: 1
+              bit_size: 5
+            - name: brf_en_rvga_q_lv
+              bit_offset: 6
+              bit_size: 1
+            - name: brf_en_rvga_i_lv
+              bit_offset: 7
+              bit_size: 1
+            - name: brf_cbpf_w2x_stg2_lv
+              bit_offset: 8
+              bit_size: 1
+            - name: brf_cbpf_w2x_stg1_lv
+              bit_offset: 9
+              bit_size: 1
+            - name: brf_cbpf_gc_lv
+              bit_offset: 10
+              bit_size: 2
+            - name: brf_cbpf_en_rc
+              bit_offset: 12
+              bit_size: 1
+            - name: brf_cbpf_fc_lv
+              bit_offset: 13
+              bit_size: 2
+            - name: brf_cbpf_bw_lv
+              bit_offset: 15
+              bit_size: 1
+            - name: brf_cbpf_vstart_lv
+              bit_offset: 16
+              bit_size: 2
+            - name: brf_cbpf_vcmref_lv
+              bit_offset: 18
+              bit_size: 2
+            - name: brf_cbpf_bm_lv
+              bit_offset: 20
+              bit_size: 3
+            - name: brf_cbpf_cc_lv
+              bit_offset: 23
+              bit_size: 4
+            - name: brf_en_cbpf_lv
+              bit_offset: 27
+              bit_size: 1
+
+        fieldset/bt_rfc::regs::RbbReg3:
+          description: "RBB_REG3"
+          fields:
+            - name: brf_en_pkdet_lv
+              bit_offset: 0
+              bit_size: 4
+            - name: brf_rvga_w2x_stg2_lv
+              bit_offset: 4
+              bit_size: 1
+            - name: brf_rvga_w2x_stg1_lv
+              bit_offset: 5
+              bit_size: 1
+            - name: brf_rvga_vstart_lv
+              bit_offset: 6
+              bit_size: 2
+            - name: brf_rvga_vcmref_lv
+              bit_offset: 8
+              bit_size: 2
+            - name: brf_rvga_bm_lv
+              bit_offset: 10
+              bit_size: 3
+            - name: brf_rvga_rz_lv
+              bit_offset: 13
+              bit_size: 3
+            - name: brf_rvga_cc_lv
+              bit_offset: 16
+              bit_size: 4
+            - name: brf_rvga_cfman_lv
+              bit_offset: 20
+              bit_size: 3
+
+        fieldset/bt_rfc::regs::RbbReg4:
+          description: "RBB_REG4"
+          fields:
+            - name: brf_pkdet_vth2q_lv
+              bit_offset: 0
+              bit_size: 4
+            - name: brf_pkdet_vth2i_lv
+              bit_offset: 4
+              bit_size: 4
+            - name: brf_pkdet_vth1q_lv
+              bit_offset: 8
+              bit_size: 4
+            - name: brf_pkdet_vth1i_lv
+              bit_offset: 12
+              bit_size: 4
+            - name: brf_dos_q_lv
+              bit_offset: 16
+              bit_size: 7
+            - name: brf_dos_i_lv
+              bit_offset: 23
+              bit_size: 7
+
+        fieldset/bt_rfc::regs::RbbReg5:
+          description: "RBB_REG5"
+          fields:
+            - name: brf_rvga_tx_lpbk_en_lv
+              bit_offset: 0
+              bit_size: 1
+            - name: brf_cbpf_bt_en_lv
+              bit_offset: 1
+              bit_size: 1
+            - name: brf_iary_bm_lv
+              bit_offset: 2
+              bit_size: 3
+            - name: brf_en_iarray_lv
+              bit_offset: 5
+              bit_size: 1
+            - name: brf_en_osdacq_lv
+              bit_offset: 6
+              bit_size: 1
+            - name: brf_en_osdaci_lv
+              bit_offset: 7
+              bit_size: 1
+            - name: brf_rstb_rccal_lv
+              bit_offset: 8
+              bit_size: 1
+            - name: brf_cbpf_capman_lv
+              bit_offset: 9
+              bit_size: 5
+            - name: brf_rccal_mancap_lv
+              bit_offset: 14
+              bit_size: 1
+            - name: brf_rccal_selxo_lv
+              bit_offset: 15
+              bit_size: 1
+            - name: brf_en_rccal_lv
+              bit_offset: 16
+              bit_size: 1
+            - name: brf_pkdet_bm_lv
+              bit_offset: 17
+              bit_size: 3
+            - name: brf_cbpf_bt_en_frc_en
+              bit_offset: 20
+              bit_size: 1
+
+        fieldset/bt_rfc::regs::RbbReg6:
+          description: "RBB_REG6"
+          fields:
+            - name: brf_cbpf_fc_lv_br
+              bit_offset: 0
+              bit_size: 2
+            - name: brf_cbpf_bm_lv_br
+              bit_offset: 2
+              bit_size: 3
+            - name: brf_cbpf_cc_lv_br
+              bit_offset: 5
+              bit_size: 4
+            - name: brf_cbpf_fc_lv_edr
+              bit_offset: 9
+              bit_size: 2
+            - name: brf_cbpf_bm_lv_edr
+              bit_offset: 11
+              bit_size: 3
+            - name: brf_cbpf_cc_lv_edr
+              bit_offset: 14
+              bit_size: 4
+            - name: brf_rvga_w2x_stg2_lv_br
+              bit_offset: 18
+              bit_size: 1
+            - name: brf_rvga_w2x_stg1_lv_br
+              bit_offset: 19
+              bit_size: 1
+            - name: brf_rvga_w2x_stg2_lv_edr
+              bit_offset: 20
+              bit_size: 1
+            - name: brf_rvga_w2x_stg1_lv_edr
+              bit_offset: 21
+              bit_size: 1
+            - name: brf_cbpf_w2x_stg2_lv_br
+              bit_offset: 22
+              bit_size: 1
+            - name: brf_cbpf_w2x_stg1_lv_br
+              bit_offset: 23
+              bit_size: 1
+            - name: brf_cbpf_w2x_stg2_lv_edr
+              bit_offset: 24
+              bit_size: 1
+            - name: brf_cbpf_w2x_stg1_lv_edr
+              bit_offset: 25
+              bit_size: 1
+            - name: brf_cbpf_bw_lv_br
+              bit_offset: 26
+              bit_size: 1
+            - name: brf_cbpf_bw_lv_edr
+              bit_offset: 27
+              bit_size: 1
+
+        fieldset/bt_rfc::regs::AdcReg:
+          description: "ADC_REG"
+          fields:
+            - name: brf_sel_ldovref_adcref_lv
+              bit_offset: 0
+              bit_size: 4
+            - name: brf_en_ldo_adcref_lv
+              bit_offset: 4
+              bit_size: 1
+            - name: brf_sel_ldovref_adc_lv
+              bit_offset: 5
+              bit_size: 4
+            - name: brf_en_ldo_adc_lv
+              bit_offset: 9
+              bit_size: 1
+            - name: brf_rstb_adc_lv
+              bit_offset: 10
+              bit_size: 1
+            - name: brf_adc_vsp_lv
+              bit_offset: 11
+              bit_size: 2
+            - name: brf_adc_cmpcl_lv
+              bit_offset: 13
+              bit_size: 3
+            - name: brf_adc_cmm_lv
+              bit_offset: 16
+              bit_size: 4
+            - name: brf_en_adc_q_lv
+              bit_offset: 20
+              bit_size: 1
+            - name: brf_en_adc_i_lv
+              bit_offset: 21
+              bit_size: 1
+
+        fieldset/bt_rfc::regs::TbbReg:
+          description: "TBB_REG"
+          fields:
+            - name: brf_sel_ldovref_dac_dvdd_lv
+              bit_offset: 0
+              bit_size: 4
+            - name: brf_sel_ldovref_dac_avdd_lv
+              bit_offset: 4
+              bit_size: 4
+            - name: brf_en_tbb_iarray_lv
+              bit_offset: 8
+              bit_size: 1
+            - name: brf_en_ldo_dac_dvdd_lv
+              bit_offset: 9
+              bit_size: 1
+            - name: brf_en_ldo_dac_avdd_lv
+              bit_offset: 10
+              bit_size: 1
+            - name: brf_en_dac_lv
+              bit_offset: 11
+              bit_size: 1
+            - name: brf_dac_start_lv
+              bit_offset: 12
+              bit_size: 1
+            - name: brf_dac_sel_clk_bar_lv
+              bit_offset: 13
+              bit_size: 1
+            - name: brf_dac_lsb_cnt_lv
+              bit_offset: 14
+              bit_size: 2
+
+        fieldset/bt_rfc::regs::AtstbufReg:
+          description: "ATSTBUF_REG"
+          fields:
+            - name: brf_atstbuf_w2x_stg2_lv
+              bit_offset: 0
+              bit_size: 1
+            - name: brf_atstbuf_w2x_stg1_lv
+              bit_offset: 1
+              bit_size: 1
+            - name: brf_atstbuf_vstart_lv
+              bit_offset: 2
+              bit_size: 2
+            - name: brf_atstbuf_vcmref_lv
+              bit_offset: 4
+              bit_size: 2
+            - name: brf_atstbuf_bm_lv
+              bit_offset: 6
+              bit_size: 3
+            - name: brf_atstbuf_rz_lv
+              bit_offset: 9
+              bit_size: 3
+            - name: brf_atstbuf_cc_lv
+              bit_offset: 12
+              bit_size: 4
+            - name: brf_atstbuf_cfman_lv
+              bit_offset: 16
+              bit_size: 3
+            - name: brf_atstbuf_man_cfsel_lv
+              bit_offset: 19
+              bit_size: 1
+            - name: brf_atstbuf_gc_lv
+              bit_offset: 20
+              bit_size: 5
+            - name: brf_atstbuf_ch_sel_lv
+              bit_offset: 25
+              bit_size: 1
+            - name: brf_en_atstbuf_lv
+              bit_offset: 26
+              bit_size: 1
+
+        fieldset/bt_rfc::regs::InccalReg1:
+          description: "INCCAL_REG1"
+          fields:
+            - name: vco3g_auto_incacal_en
+              bit_offset: 0
+              bit_size: 1
+            - name: vco3g_auto_incfcal_en
+              bit_offset: 1
+              bit_size: 1
+            - name: vco3g_incacal_wait_time
+              bit_offset: 2
+              bit_size: 6
+            - name: vco3g_incfcal_wait_time
+              bit_offset: 8
+              bit_size: 6
+            - name: vco3g_idac_offset
+              bit_offset: 14
+              bit_size: 7
+            - name: vco3g_pdx_offset
+              bit_offset: 21
+              bit_size: 8
+            - name: inccal_start
+              bit_offset: 29
+              bit_size: 1
+            - name: frc_inccal_clk_on
+              bit_offset: 30
+              bit_size: 1
+
+        fieldset/bt_rfc::regs::InccalReg2:
+          description: "INCCAL_REG2"
+          fields:
+            - name: vco5g_auto_incacal_en
+              bit_offset: 0
+              bit_size: 1
+            - name: vco5g_auto_incfcal_en
+              bit_offset: 1
+              bit_size: 1
+            - name: vco5g_incacal_wait_time
+              bit_offset: 2
+              bit_size: 6
+            - name: vco5g_incfcal_wait_time
+              bit_offset: 8
+              bit_size: 6
+            - name: vco5g_idac_offset
+              bit_offset: 14
+              bit_size: 7
+            - name: vco5g_pdx_offset
+              bit_offset: 21
+              bit_size: 8
+
+        fieldset/bt_rfc::regs::RoscalReg1:
+          description: "ROSCAL_REG1"
+          fields:
+            - name: roscal_start
+              bit_offset: 0
+              bit_size: 1
+            - name: roscal_bypass
+              bit_offset: 1
+              bit_size: 1
+            - name: en_rosdac_i
+              bit_offset: 2
+              bit_size: 1
+            - name: en_rosdac_q
+              bit_offset: 3
+              bit_size: 1
+            - name: roscal_ta
+              bit_offset: 4
+              bit_size: 9
+            - name: roscal_tb
+              bit_offset: 13
+              bit_size: 4
+            - name: roscal_tc
+              bit_offset: 17
+              bit_size: 7
+
+        fieldset/bt_rfc::regs::RoscalReg2:
+          description: "ROSCAL_REG2"
+          fields:
+            - name: roscal_done
+              bit_offset: 0
+              bit_size: 1
+            - name: dos_i_sw
+              bit_offset: 1
+              bit_size: 7
+            - name: dos_q_sw
+              bit_offset: 8
+              bit_size: 7
+
+        fieldset/bt_rfc::regs::RcroscalReg:
+          description: "RCROSCAL_REG"
+          fields:
+            - name: ros_adc_q
+              bit_offset: 0
+              bit_size: 10
+            - name: ros_adc_i
+              bit_offset: 10
+              bit_size: 10
+            - name: rccal_done
+              bit_offset: 20
+              bit_size: 1
+            - name: rccal_start
+              bit_offset: 21
+              bit_size: 1
+            - name: rc_capcode_offset
+              bit_offset: 22
+              bit_size: 4
+            - name: rc_capcode
+              bit_offset: 26
+              bit_size: 5
+
+        fieldset/bt_rfc::regs::PacalReg:
+          description: "PACAL_REG"
+          fields:
+            - name: pacal_start
+              bit_offset: 0
+              bit_size: 1
+            - name: pacal_done
+              bit_offset: 1
+              bit_size: 1
+            - name: sgn_cal_rslt
+              bit_offset: 2
+              bit_size: 1
+            - name: bc_cal_rslt
+              bit_offset: 3
+              bit_size: 4
+            - name: pacal_rdy
+              bit_offset: 7
+              bit_size: 1
+            - name: pa_rstb_frc_en
+              bit_offset: 8
+              bit_size: 1
+            - name: pacal_clk_en
+              bit_offset: 9
+              bit_size: 1
+
+        fieldset/bt_rfc::regs::CuAddrReg1:
+          description: "CU_ADDR_REG1"
+          fields:
+            - name: rxon_cfg_addr
+              bit_offset: 0
+              bit_size: 12
+            - name: rxoff_cfg_addr
+              bit_offset: 16
+              bit_size: 12
+
+        fieldset/bt_rfc::regs::CuAddrReg2:
+          description: "CU_ADDR_REG2"
+          fields:
+            - name: txon_cfg_addr
+              bit_offset: 0
+              bit_size: 12
+            - name: txoff_cfg_addr
+              bit_offset: 16
+              bit_size: 12
+
+        fieldset/bt_rfc::regs::CuAddrReg3:
+          description: "CU_ADDR_REG3"
+          fields:
+            - name: bt_txon_cfg_addr
+              bit_offset: 0
+              bit_size: 12
+            - name: bt_txoff_cfg_addr
+              bit_offset: 16
+              bit_size: 12
+
+        fieldset/bt_rfc::regs::CalAddrReg1:
+          description: "CAL_ADDR_REG1"
+          fields:
+            - name: ble_rx_cal_addr
+              bit_offset: 0
+              bit_size: 12
+            - name: bt_rx_cal_addr
+              bit_offset: 16
+              bit_size: 12
+
+        fieldset/bt_rfc::regs::CalAddrReg2:
+          description: "CAL_ADDR_REG2"
+          fields:
+            - name: ble_tx_cal_addr
+              bit_offset: 0
+              bit_size: 12
+            - name: bt_tx_cal_addr
+              bit_offset: 16
+              bit_size: 12
+
+        fieldset/bt_rfc::regs::CalAddrReg3:
+          description: "CAL_ADDR_REG3"
+          fields:
+            - name: txdc_cal_addr
+              bit_offset: 0
+              bit_size: 12
+
+        fieldset/bt_rfc::regs::AgcReg:
+          description: "AGC_REG"
+          fields:
+            - name: lna_gain_frc_en
+              bit_offset: 0
+              bit_size: 1
+            - name: cbpf_gain_frc_en
+              bit_offset: 1
+              bit_size: 1
+            - name: vga_gain_frc_en
+              bit_offset: 2
+              bit_size: 1
+            - name: lna_gc
+              bit_offset: 3
+              bit_size: 4
+            - name: cbpf_gc
+              bit_offset: 7
+              bit_size: 2
+            - name: vga_gc
+              bit_offset: 9
+              bit_size: 5
+
+        fieldset/bt_rfc::regs::IqPwrReg1:
+          description: "IQ_PWR_REG1"
+          fields:
+            - name: tx_dc_cal_coef0
+              bit_offset: 0
+              bit_size: 14
+            - name: tx_dc_cal_coef1
+              bit_offset: 14
+              bit_size: 14
+            - name: edr_tmxbuf_gc_gfsk
+              bit_offset: 28
+              bit_size: 4
+
+        fieldset/bt_rfc::regs::IqPwrReg2:
+          description: "IQ_PWR_REG2"
+          fields:
+            - name: tx_dc_cal_offset_q
+              bit_offset: 0
+              bit_size: 11
+            - name: brf_trf_edr_pa_bm_lv
+              bit_offset: 11
+              bit_size: 5
+            - name: tx_dc_cal_offset_i
+              bit_offset: 16
+              bit_size: 11
+            - name: edr_lpf_bypass
+              bit_offset: 27
+              bit_size: 1
+            - name: edr_tmxbuf_gc_dpsk
+              bit_offset: 28
+              bit_size: 4

--- a/transform/common/mailbox.yaml
+++ b/transform/common/mailbox.yaml
@@ -1,3 +1,13 @@
+# MAILBOX Peripheral Definition
+#
+# WARNING: This file contains register definitions derived from reverse-engineering
+# the SiFli C SDK. These are NOT official SVD definitions from the vendor.
+#
+# Source: SiFli-SDK headers and register maps
+# The vendor has declined to include these registers in the official SVD.
+#
+# Use at your own risk. Register layouts may be incomplete or inaccurate.
+
 transforms:
   - !AddPeripherals
       devices: .*

--- a/transform/common/patch.yaml
+++ b/transform/common/patch.yaml
@@ -1,3 +1,13 @@
+# PATCH Peripheral Definition
+#
+# WARNING: This file contains register definitions derived from reverse-engineering
+# the SiFli C SDK. These are NOT official SVD definitions from the vendor.
+#
+# Source: SiFli-SDK headers and register maps
+# The vendor has declined to include these registers in the official SVD.
+#
+# Use at your own risk. Register layouts may be incomplete or inaccurate.
+
 transforms:
   - !AddPeripherals
       devices: .*


### PR DESCRIPTION
添加蓝牙相关 LPSYS 外设的 transform yaml：
- BT_RFC (0x4008_2800) - 蓝牙射频控制器
- BT_PHY (0x4008_4000) - 蓝牙物理层
- BT_MAC (0x4009_0000) - 蓝牙 MAC 层

同时为已有的 LPSYS 外设 transform 补充了文档警告说明。