### PR TITLE
feat(lpsys): add PTC2 peripheral and PTC Op enum

### DIFF
--- a/transform/SF32LB52x.yaml
+++ b/transform/SF32LB52x.yaml
@@ -31,7 +31,7 @@ transforms:
   # LPSYS peripherals, reserved for lpsys firmware
   - !DeletePeripherals
       devices: .*
-      from: (LPTIM3|BTIM[34]|CRC2|PTC2|WDT2|USART[45])
+      from: (LPTIM3|BTIM[34]|CRC2|WDT2|USART[45])
 
   # ------------------------------ PINMUX ------------------------------
   # PINMUX pad_pa[39, 42] is different with pad_pa[0, 38], [43, 44]

--- a/transform/SF32LB52x.yaml
+++ b/transform/SF32LB52x.yaml
@@ -10,6 +10,7 @@ includes:
   - common/mailbox.yaml
   - common/patch.yaml
   - common/lcdc.yaml
+  - common/ptc.yaml
   # Bluetooth peripherals (LPSYS, not in SVD)
   - common/bt_rfc.yaml
   - common/bt_phy.yaml

--- a/transform/common/ptc.yaml
+++ b/transform/common/ptc.yaml
@@ -1,0 +1,26 @@
+transforms:
+  - !Add
+      ir:
+        enum/ptc::vals::Op:
+          bit_size: 3
+          variants:
+            - name: Write
+              description: "Direct write data"
+              value: 0
+            - name: Xor
+              description: "Read then XOR with data and write back"
+              value: 4
+            - name: Or
+              description: "Read then OR with data and write back"
+              value: 5
+            - name: And
+              description: "Read then AND with data and write back"
+              value: 6
+            - name: Add
+              description: "Read then add with data and write back"
+              value: 7
+
+  - !ModifyFieldsEnum
+      fieldset: ptc::regs::Tcr\d+
+      field: op
+      enum: ptc::vals::Op


### PR DESCRIPTION
- 从 DeletePeripherals 中移除 PTC2，使其保留在生成代码中
- 为 PTC 外设添加 Op 枚举，用于 task operation 字段
- 添加 ptc.yaml transform